### PR TITLE
Corrected waring to warning

### DIFF
--- a/module/common/support.py
+++ b/module/common/support.py
@@ -182,7 +182,7 @@ async def reverse_lookup(resolver, ip):
             log.debug2(f"PTR record for {ip}: {resolved_name}")
 
         else:
-            log.waring(f"PTR record contains invalid characters: {response.name}")
+            log.warning(f"PTR record contains invalid characters: {response.name}")
 
     return {ip: resolved_name}
 


### PR DESCRIPTION
The log method was spelled wrong in support.py causing an error if the hostname contained an invalid character