### PR TITLE
add a configuration parameter to allow skipping the sync of VM notes

### DIFF
--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -72,7 +72,8 @@ class VMWareHandler:
         "vm_tenant_relation": None,
         "dns_name_lookup": False,
         "custom_dns_servers": None,
-        "set_primary_ip": "when-undefined"
+        "set_primary_ip": "when-undefined",
+        "skip_vm_comments": "False"
     }
 
     init_successful = False
@@ -1918,7 +1919,8 @@ class VMWareHandler:
                        if isinstance(comp, vim.vm.device.VirtualDisk)
                         ]) / 1024 / 1024)
 
-        annotation = get_string_or_none(grab(obj, "config.annotation"))
+        if bool(self.skip_vm_comments) is False:
+            annotation = get_string_or_none(grab(obj, "config.annotation"))
 
         # assign vm_tenant_relation
         tenant_name = None
@@ -1940,7 +1942,7 @@ class VMWareHandler:
 
         if platform is not None:
             vm_data["platform"] = {"name": platform}
-        if annotation is not None:
+        if bool(self.skip_vm_comments) is False and annotation is not None:
             vm_data["comments"] = annotation
         if tenant_name is not None:
             vm_data["tenant"] = {"name": tenant_name}

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -1919,6 +1919,7 @@ class VMWareHandler:
                        if isinstance(comp, vim.vm.device.VirtualDisk)
                         ]) / 1024 / 1024)
 
+        annotation = None
         if bool(self.skip_vm_comments) is False:
             annotation = get_string_or_none(grab(obj, "config.annotation"))
 
@@ -1942,7 +1943,7 @@ class VMWareHandler:
 
         if platform is not None:
             vm_data["platform"] = {"name": platform}
-        if bool(self.skip_vm_comments) is False and annotation is not None:
+        if annotation is not None:
             vm_data["comments"] = annotation
         if tenant_name is not None:
             vm_data["tenant"] = {"name": tenant_name}

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -188,5 +188,7 @@ permitted_subnets = 172.16.0.0/12, 10.0.0.0/8, 192.168.0.0/16, fd00::/8
 
 #set_primary_ip = when-undefined
 
+# Do not sync notes from a VM in vCenter to the comments field on a VM in netbox
+# skip_vm_comments = False
 
 # EOF


### PR DESCRIPTION
When using Veeam backup, the VM notes are updated with the backup job details.
These contain a date field, so it's updated frequently.

I've added a config parameter that allow skipping the sync of these notes into the comments field in netbox.