### PR TITLE
add option to not sync vm templates

### DIFF
--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -73,7 +73,8 @@ class VMWareHandler:
         "dns_name_lookup": False,
         "custom_dns_servers": None,
         "set_primary_ip": "when-undefined",
-        "skip_vm_comments": "False"
+        "skip_vm_comments": "False",
+        "skip_vm_templates": False
     }
 
     init_successful = False
@@ -1865,6 +1866,12 @@ class VMWareHandler:
 
         # get VM power state
         status = "active" if get_string_or_none(grab(obj, "runtime.powerState")) == "poweredOn" else "offline"
+
+        # check if vm is template
+        template = grab(obj, "config.template")
+        if bool(self.skip_vm_templates) is True and template is True:
+            log.debug2(f"VM '{name}' is a template. Skipping")
+            return
 
         # ignore offline VMs during first run
         if self.parsing_vms_the_first_time is True and status == "offline":

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -73,7 +73,7 @@ class VMWareHandler:
         "dns_name_lookup": False,
         "custom_dns_servers": None,
         "set_primary_ip": "when-undefined",
-        "skip_vm_comments": "False",
+        "skip_vm_comments": False,
         "skip_vm_templates": False
     }
 

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -74,7 +74,7 @@ class VMWareHandler:
         "custom_dns_servers": None,
         "set_primary_ip": "when-undefined",
         "skip_vm_comments": False,
-        "skip_vm_templates": False
+        "skip_vm_templates": True
     }
 
     init_successful = False

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -192,6 +192,6 @@ permitted_subnets = 172.16.0.0/12, 10.0.0.0/8, 192.168.0.0/16, fd00::/8
 # skip_vm_comments = False
 
 # Do not sync template VMs
-#skip_vm_templates = False
+#skip_vm_templates = True
 
 # EOF

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -191,4 +191,7 @@ permitted_subnets = 172.16.0.0/12, 10.0.0.0/8, 192.168.0.0/16, fd00::/8
 # Do not sync notes from a VM in vCenter to the comments field on a VM in netbox
 # skip_vm_comments = False
 
+# Do not sync template VMs
+#skip_vm_templates = False
+
 # EOF


### PR DESCRIPTION
Added an config parameter that allows to skip the sync of VM templates.
Also the `skip_vm_comments` boolean from the previous PR was quoted, which is fixed here.