### PR TITLE
set dummy value if a host device vendor/model cannot be retrieved

### DIFF
--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -1450,6 +1450,12 @@ class VMWareHandler:
         product_version = get_string_or_none(grab(obj, "summary.config.product.version"))
         platform = f"{product_name} {product_version}"
 
+        # if the device vendor/model cannot be retrieved (due to problem on the host), set a dummy value so the host still gets synced
+        if manufacturer is None:
+            manufacturer = "ErrorCouldNotRetrieveVendor"
+        if model is None:
+            model = "ErrorCouldNotRetrieveModel"
+
         # get status
         status = "offline"
         if get_string_or_none(grab(obj, "summary.runtime.connectionState")) == "connected":

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -1452,9 +1452,9 @@ class VMWareHandler:
 
         # if the device vendor/model cannot be retrieved (due to problem on the host), set a dummy value so the host still gets synced
         if manufacturer is None:
-            manufacturer = "ErrorCouldNotRetrieveVendor"
+            manufacturer = "Generic Vendor"
         if model is None:
-            model = "ErrorCouldNotRetrieveModel"
+            model = "Generic Model"
 
         # get status
         status = "offline"


### PR DESCRIPTION
If the vendor/model cannot be retrieved from an ESXi host, set a dummy value so the host still gets imported instead of throwing errors upon adding the device and its dependencies.
The problem is located on the host, but it would still be useful to get imported into netbox, until the problem is fixed on the host.

Case example which would prevent the host from being added:

```
PS Microsoft.PowerShell.Core\FileSystem::\\tsclient\C\scripts> $esx033.ExtensionData.Hardware.SystemInfo
Vendor               : 
Model                :
Uuid                 : 4c4c4544-004b-4b10-8050-b3c04f323132
OtherIdentifyingInfo : {VMware.Vim.HostSystemIdentificationInfo, VMware.Vim.HostSystemIdentificationInfo, VMware.Vim.HostSystemIdentificationInfo, VMware.Vim.HostSystemIdentificationInfo...}
SerialNumber         : 3xxxxxx
```