### PR TITLE
Add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+settings.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.9-alpine
+
+# Install dependencies
+RUN apk add --no-cache build-base libffi-dev
+
+# Prepare the application
+COPY . /opt
+RUN cd /opt && pip3 install -r requirements.txt
+
+# Run the application
+WORKDIR /opt
+ENTRYPOINT ["python3", "netbox-sync.py"]

--- a/README.md
+++ b/README.md
@@ -67,7 +67,19 @@ virtualenv-3 .env || virtualenv .env
 pip3 install -r requirements.txt || pip install -r requirements.txt
 ```
 
-### Accounts and tokens
+## Docker
+
+Run the application in docker container
+
+* The application working directory is ```/opt```
+* Required to mount your ```settings.ini```
+
+```
+docker build -t netbox-sync .
+docker run --rm -it -v $(pwd)/settings.ini:/opt/settings.ini netbox-sync [some args...]
+```
+
+## Accounts and tokens
 In order to read data from a vCenter and updated data in NetBox you need credentials in both instances.
 
 ### vCenter user


### PR DESCRIPTION
Support for running netbox-sync in docker container.

## Commands

### Docker build
```
$ docker build -t netbox-sync .
```

### Run in docker with your settings.ini
```
$ docker run --rm -it -v $(pwd)/settings.ini:/app/settings.ini netbox-sync [some args...]
```