### PR TITLE
Fixed requirements due to incompatibility with requests 2.24.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 packaging
-urllib3
+urllib3==1.25.11
 wheel
 requests==2.24.0
 pyvmomi==6.7.3


### PR DESCRIPTION
Tried a fresh install on Ubuntu 20.04 LTS.  
Fails while trying to installs `pyvmomi` due to dependencies to `requests` module.  
`requests` module v2.24.0 doesn't allow `urllib3` >= 1.26 usage ... forcing `urllib3` to 1.25.11 did the trick ! 