### PR TITLE
Update connection.py

### DIFF
--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -824,7 +824,7 @@ class VMWareHandler(SourceBase):
             if label is None:
                 continue
 
-            name = NetBoxObject.format_slug(f"vcsa-{label}", 50).replace("--", "-").strip("-")
+            name = NetBoxObject.format_slug(f"vcsa_{label}", 50).replace("--", "_").strip("-")
 
             self.add_update_custom_field({
                 "name": name,


### PR DESCRIPTION
first of all big thanks for your great work!

Importing "Custom Attributes" from VMware as "custom field" into Netbox fails with this error:

`2022-03-03 19:49:47,544 - ERROR: NetBox returned: POST /api/extras/custom-fields/ Bad Request`
`2022-03-03 19:49:47,544 - ERROR: NetBox returned body: {'name': ['Only alphanumeric characters and underscores are allowed.']}`
`2022-03-03 19:49:47,545 - ERROR: Request Failed for custom field. Used data: {'name': 'vcsa_veem-backup', 'label': 'Veem Backup', 'content_types': ['virtualization.virtualmachine'], 'type': 'text', 'description': "vCenter 'vCenter' synced custom attribute 'Veem Backup'"}`

I was able to fix the issue with changes in PR.
Best regards
Mo