### PR TITLE
reformats custom_fields from VMware

### DIFF
--- a/module/netbox/object_classes.py
+++ b/module/netbox/object_classes.py
@@ -414,39 +414,6 @@ class NetBoxObject:
         # Enforce max length
         return text[0:max_len]
 
-    def format_label(text=None, max_len=150):
-        """
-        Format string to comply to NetBox custom field acceptable pattern and max length.
-
-        Parameters
-        ----------
-        text: str
-            name to format into a NetBox custom field
-
-        Returns
-        -------
-        str: input name formatted
-        """
-
-        if text is None or len(text) == 0:
-            raise AttributeError("Argument 'text' can't be None or empty!")
-
-        permitted_chars = (
-            "abcdefghijklmnopqrstuvwxyz"  # alphabet
-            "0123456789"  # numbers
-            "_"  # symbols
-        )
-
-        # Replace separators with dash
-        for sep in [" ", ",", "."]:
-            text = text.replace(sep, "_")
-
-        # Strip unacceptable characters
-        text = "".join([c for c in text.lower() if c in permitted_chars])
-
-        # Enforce max length
-        return text[0:max_len]
-
     # noinspection PyAttributeOutsideInit
     def update(self, data=None, read_from_netbox=False, source=None):
         """

--- a/module/netbox/object_classes.py
+++ b/module/netbox/object_classes.py
@@ -414,6 +414,39 @@ class NetBoxObject:
         # Enforce max length
         return text[0:max_len]
 
+    def format_label(text=None, max_len=150):
+        """
+        Format string to comply to NetBox custom field acceptable pattern and max length.
+
+        Parameters
+        ----------
+        text: str
+            name to format into a NetBox custom field
+
+        Returns
+        -------
+        str: input name formatted
+        """
+
+        if text is None or len(text) == 0:
+            raise AttributeError("Argument 'text' can't be None or empty!")
+
+        permitted_chars = (
+            "abcdefghijklmnopqrstuvwxyz"  # alphabet
+            "0123456789"  # numbers
+            "_"  # symbols
+        )
+
+        # Replace separators with dash
+        for sep in [" ", ",", "."]:
+            text = text.replace(sep, "_")
+
+        # Strip unacceptable characters
+        text = "".join([c for c in text.lower() if c in permitted_chars])
+
+        # Enforce max length
+        return text[0:max_len]
+
     # noinspection PyAttributeOutsideInit
     def update(self, data=None, read_from_netbox=False, source=None):
         """

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -824,7 +824,7 @@ class VMWareHandler(SourceBase):
             if label is None:
                 continue
 
-            name = NetBoxObject.format_slug(f"vcsa_{label}", 50).replace("-", "_").strip("-")
+            name = NetBoxObject.format_slug(f"vcsa_{label}", 50).replace("-", "_").strip("-_")
 
             self.add_update_custom_field({
                 "name": name,

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -824,15 +824,14 @@ class VMWareHandler(SourceBase):
             if label is None:
                 continue
 
-            custom = NetBoxObject.format_label(f"{label}").replace("-", "_").strip("-")
-            name = NetBoxObject.format_slug(f"vcsa_{custom}", 50).replace("--", "_").strip("-")
+            name = NetBoxObject.format_slug(f"vcsa_{label}", 50).replace("-", "_").strip("-")
 
             self.add_update_custom_field({
                 "name": name,
-                "label": custom,
+                "label": label,
                 "content_types": [content_type],
                 "type": "text",
-                "description": f"vCenter '{self.name}' synced custom attribute '{custom}'"
+                "description": f"vCenter '{self.name}' synced custom attribute '{label}'"
             })
 
             return_custom_fields[name] = value

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -824,14 +824,15 @@ class VMWareHandler(SourceBase):
             if label is None:
                 continue
 
-            name = NetBoxObject.format_slug(f"vcsa_{label}", 50).replace("--", "_").strip("-_")
+            custom = NetBoxObject.format_label(f"{label}").replace("-", "_").strip("-")
+            name = NetBoxObject.format_slug(f"vcsa_{custom}", 50).replace("--", "_").strip("-")
 
             self.add_update_custom_field({
                 "name": name,
-                "label": label,
+                "label": custom,
                 "content_types": [content_type],
                 "type": "text",
-                "description": f"vCenter '{self.name}' synced custom attribute '{label}'"
+                "description": f"vCenter '{self.name}' synced custom attribute '{custom}'"
             })
 
             return_custom_fields[name] = value


### PR DESCRIPTION
We have custom field names with dashes in it. Netbox doesn't like dashes, only underscores, so I changed the code a bit. 
