### PR TITLE
Adding Dell ServiceTag as custom field from check_redfish inventory import

### DIFF
--- a/module/sources/check_redfish/import_inventory.py
+++ b/module/sources/check_redfish/import_inventory.py
@@ -306,6 +306,12 @@ class CheckRedfish(SourceBase):
             device_data["serial"] = serial
         if name is not None and self.overwrite_host_name is True:
             device_data["name"] = name
+        if get_string_or_none(grab(system, "manufacturer")) == "Dell Inc.":
+            chassi = grab(self.inventory_file_content, "inventory.chassi.0")
+            if chassi and "sku" in chassi:
+                device_data["custom_fields"]["service_tag"] = chassi["sku"]
+            else:
+                log.warning(f"No chassi or sku data found for '{self.device_object.get_display_name()}' in inventory file.")
 
         self.device_object.update(data=device_data, source=self)
 
@@ -1108,6 +1114,17 @@ class CheckRedfish(SourceBase):
             ],
             "type": "text",
             "description": "Shows the currently discovered health status"
+        })
+
+        # add ServiceTag
+        self.add_update_custom_field({
+            "name": "service_tag",
+            "label": "Service Tag",
+            "content_types": [
+                "dcim.device"
+            ],
+            "type": "text",
+            "description": "Dell Service Tag"
         })
 
 # EOF


### PR DESCRIPTION
This PR aims to add **Service Tag** custom field support for DELL devices using the **check_redfish** inventory import.
Since the JSON data exported with check_redfish for DELL devices contains both the serial number and the service tag (called SKU in the JSON), it will be very useful to import the service tag, as only the serial number is currently imported.

Tested with:
- Dell PowerEdge R650
- Dell PowerEdge R740xd2
- Dell PowerEdge R750xa