### PR TITLE
enable configuration option ip_tenant_inheritance_order with inventory import

### DIFF
--- a/settings-example.ini
+++ b/settings-example.ini
@@ -347,4 +347,13 @@ permitted_subnets = 172.16.0.0/12, 10.0.0.0/8, 192.168.0.0/16, fd00::/8
 # if False only data which is not preset in NetBox will be added
 #overwrite_interface_attributes = True
 
+# define in which order the IP address tenant will be assigned if tenant is undefined.
+# possible values:
+#  * device : host or VM tenant will be assigned to the IP address
+#  * prefix : if the IP address belongs to an existing prefix and this prefix has a tenant assigned, then this one is used
+#  * disabled : no tenant assignment to the IP address will be performed
+# the order of the definition is important, the default is "device, prefix" which means:
+# If the device has a tenant then this one will be used. If not, the prefix tenant will be used if defined
+#ip_tenant_inheritance_order = device, prefix
+
 # EOF


### PR DESCRIPTION
This PR aims to add the configuration option `ip_tenant_inheritance_order` with inventory import (check-redfish) as already available with vmware import.