### PR TITLE
Set host/vm_role_relation default value. Or the sync will fail.

### DIFF
--- a/module/sources/vmware/config.py
+++ b/module/sources/vmware/config.py
@@ -153,8 +153,8 @@ class VMWareConfig(ConfigBase):
                                 ConfigOption("host_role_relation",
                                              str,
                                              description="""\
-                                             Define the NetBox device role used for hosts and VMs. The default is
-                                             set to "Server". This is done with a comma separated key = value list.
+                                             Define the NetBox device role used for hosts and VMs.
+                                             This is done with a comma separated key = value list.
                                                key: defines a hosts/VM name as regex
                                                value: defines the NetBox role name (use quotes if name contains commas)
                                              """,

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -207,12 +207,12 @@ password = super-secret
 ;   value: defines the desired NetBox platform name
 ;vm_platform_relation = centos-7.* = centos7, microsoft-windows-server-2016.* = Windows2016
 
-; Define the NetBox device role used for hosts and VMs. The default is
-; set to "Server". This is done with a comma separated key = value list.
+; Define the NetBox device role used for hosts and VMs.
+; This is done with a comma separated key = value list.
 ;   key: defines a hosts/VM name as regex
 ;   value: defines the NetBox role name (use quotes if name contains commas)
-;host_role_relation = .* = Server
-;vm_role_relation = .* = Server
+host_role_relation = .* = Server
+vm_role_relation = .* = Server
 
 ; Define NetBox tags which are assigned to a cluster, host or VM. This is
 ; done with a comma separated key = value list.


### PR DESCRIPTION
In this commit 56778467d88c52afa385b64bf66d7f11ae3fd26e, removes fallback for host/vm role assignment 'Server'

If I execute `python netbox-sync.py`, it will throw exception.

```
ERROR: NetBox returned: POST /api/dcim/devices/ Bad Request
ERROR: NetBox returned body: {'device_role': ['This field is required.']}
```

So, I think we should set default value in config file due to the commit remove the default value in code.