### PR TITLE
Update Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,9 @@
 settings.ini
+.dockerignore
+Dockerfile
+.git*
+.github
+docs
+scripts
+*.yaml
+requirements_3.6.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 packaging
-urllib3==1.26.12
+urllib3==1.26.16
 wheel
 requests==2.31.0
 pyvmomi==7.0.3


### PR DESCRIPTION
Hi,
I just updated the Dockerfile of netbox-sync image. Here's a recap:

- Update base image to debian 12
- Install dependencies via venv in order to avoid copy of useless packages in the next stage
- Do not upgrade images as base images are always upgraded and it is not a common best practice
- Remove pip install wheel as is already specified in requirements.txt
- Changed from adduser and addgroup to useradd and groupadd
- Use dockerignore instead of copy specific files
- Removed dockerfile from image. Could lead to a security flaw/issue.
- Updated urlib package to the latest minor
- Added PATH and TZ environment variables. Former is needed to use venv packages, latter to have consistent logging time.


Other packages, in particular pyvmomi needs an update, but there might be some braking changes to deal with.