### PR TITLE
adds cluster without site relation config #301

### DIFF
--- a/module/netbox/object_classes.py
+++ b/module/netbox/object_classes.py
@@ -539,6 +539,12 @@ class NetBoxObject:
                 if type_check_failed is True:
                     continue
 
+            # allows an empty site for netbox objects where a site is not mandatory
+            # required for clusters and sub-objects without site reference
+            if isinstance(self, (NBCluster, NBVM, NBVLAN)) and key == "site" and "name" in value and value["name"] is None:
+                parsed_data[key] = None
+                continue
+
             # this is meant to be reference to a different object
             if defined_value_type in NetBoxObject.__subclasses__() and defined_value_type != NBCustomField:
 

--- a/module/sources/vmware/config.py
+++ b/module/sources/vmware/config.py
@@ -121,9 +121,13 @@ class VMWareConfig(ConfigBase):
                                              address it is important to pick the correct site.
                                              A VM always depends on the cluster site relation
                                              a cluster can be specified as "Cluster-name" or
-                                             "Datacenter-name/Cluster-name" if multiple clusters have the same name
+                                             "Datacenter-name/Cluster-name" if multiple clusters have the same name.
+                                             When a vCenter cluster consists of hosts from multiple NetBox sites, 
+                                             it is possible to leave the site for a NetBox cluster empty. All VMs from 
+                                             this cluster will then also have no site reference. 
+                                             The keyword "<NONE>" can be used as a value for this.
                                              """,
-                                             config_example="Cluster_NYC = New York, Cluster_FFM.* = Frankfurt, Datacenter_TOKIO/.* = Tokio"),
+                                             config_example="Cluster_NYC = New York, Cluster_FFM.* = Frankfurt, Datacenter_TOKIO/.* = Tokio, Cluster_MultiSite = <NONE>"),
                                 ConfigOption("host_site_relation",
                                              str,
                                              description="""Same as cluster site but on host level.

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -478,6 +478,11 @@ class VMWareHandler(SourceBase):
             site_name = self.site_name
             log.debug(f"No site relation for '{object_name}' found, using default site '{site_name}'")
 
+        # set the site for cluster to None if None-keyword ("<NONE>") is set via cluster_site_relation
+        if object_type == NBCluster and site_name == "<NONE>":
+            site_name = None
+            log.debug2(f"Site relation for '{object_name}' set to None")
+
         return site_name
 
     def get_object_based_on_macs(self, object_type, mac_list=None):

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -183,8 +183,12 @@ password = super-secret
 ; address it is important to pick the correct site.
 ; A VM always depends on the cluster site relation
 ; a cluster can be specified as "Cluster-name" or
-; "Datacenter-name/Cluster-name" if multiple clusters have the same name
-;cluster_site_relation = Cluster_NYC = New York, Cluster_FFM.* = Frankfurt, Datacenter_TOKIO/.* = Tokio
+; "Datacenter-name/Cluster-name" if multiple clusters have the same name.
+; When a vCenter cluster consists of hosts from multiple NetBox sites,
+; it is possible to leave the site for a NetBox cluster empty. All VMs from
+; this cluster will then also have no site reference.
+; The keyword "<NONE>" can be used as a value for this.
+;cluster_site_relation = Cluster_NYC = New York, Cluster_FFM.* = Frankfurt, Datacenter_TOKIO/.* = Tokio, Cluster_MultiSite = <NONE>
 
 ; Same as cluster site but on host level. If unset it will fall back to
 ; cluster_site_relation


### PR DESCRIPTION
As discussed together in #301

This adds the possibility to add a NetBox cluster without site-relation. This is necessary if a vCenter cluster consists of hosts located in multiple NetBox sites.
`cluster_site_relation: Cluster_MultiSite = <NONE>`

As well as installing the keyword check, I unfortunately had to change the code so that no new None site is created.
I have also described how to configure the whole thing in the configuration file and updated the example file provided.

I hope I haven't missed anything. 

closes #301
