### PR TITLE
Source indication in vmware tags description

### DIFF
--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -676,7 +676,8 @@ class VMWareHandler(SourceBase):
                 # noinspection PyBroadException
                 try:
                     tag_name = self.tag_session.tagging.Tag.get(tag_id).name
-                    tag_description = self.tag_session.tagging.Tag.get(tag_id).description
+                    tag_prefix_source = f"NetBox-synced {self.name}"
+                    tag_description = f"{tag_prefix_source} {self.tag_session.tagging.Tag.get(tag_id).description}"
                 except Exception as e:
                     log.error(f"Unable to retrieve vCenter tag '{tag_id}' for '{obj.name}': {e}")
                     continue


### PR DESCRIPTION
As the commit says, I added an indication about the synced source in vmware tags description.

I have a lot of tags and I don't know which are manually added and which ones are added from netbox-sync and from which source (in particular when description is empty).
