### PR TITLE
Add a domain name if not present in a vm's name

### DIFF
--- a/module/sources/vmware/config.py
+++ b/module/sources/vmware/config.py
@@ -252,6 +252,14 @@ class VMWareConfig(ConfigBase):
                          bool,
                          description="strip domain part from VM name before syncing VM to NetBox",
                          default_value=False),
+            ConfigOption("add_vm_domain_name",
+                         str,
+                         description="If no domain, add this to it when syncing VM to NetBox",
+                         config_example="example.com"),
+            ConfigOption("keep_vm_domain_name_filter",
+                         str,
+                         description="Pattern for which domain names we keep, vs adding bits or truncating",
+                         config_example=".*example.(com|net)$"),
             ConfigOptionGroup(title="tag source",
                               description="""\
                               sync tags assigned to clusters, hosts and VMs in vCenter to NetBox

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -10,6 +10,7 @@
 import datetime
 import pprint
 import ssl
+import re
 from ipaddress import ip_address, ip_interface
 from urllib.parse import unquote
 
@@ -1984,7 +1985,13 @@ class VMWareHandler(SourceBase):
 
         name = get_string_or_none(grab(obj, "name"))
 
-        if name is not None and self.settings.strip_vm_domain_name is True:
+        if name is not None and self.settings.keep_vm_domain_name_filter is not None:
+            vm_domain_name_pattern = re.compile(self.settings.keep_vm_domain_name_filter)
+            if vm_domain_name_pattern.search(name):
+                name = name
+            else:
+                name = name + "." + self.settings.add_vm_domain_name
+        elif name is not None and self.settings.strip_vm_domain_name is True:
             name = name.split(".")[0]
 
         #

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -282,6 +282,12 @@ password = super-secret
 ; strip domain part from VM name before syncing VM to NetBox
 ;strip_vm_domain_name = False
 
+; domains we expect at end of FQDN:
+;keep_vm_domain_name_pattern = .*(example\.com|example\.net)$
+
+; add this domain if domain isn't an FQDN
+;add_vm_domain_name = example.com
+
 ; tag source options
 
 ; sync tags assigned to clusters, hosts and VMs in vCenter to NetBox


### PR DESCRIPTION
Tested and works for me...

Purpose explained in #355 

Two new params. Intended to handle these types of things:
- shortname -> shortname.example.com (add domain)
- foo.site1 -> foo.site1.example.com (add domain)
- foo.site2.example.com -> foo.site2.example.com (no change)
- foobar.example.net -> foobar.example.net

For when names in vCenter have an implied domain if not included.