### PR TITLE
Introduced an option to disable physical nic updates in Netbox

### DIFF
--- a/module/sources/vmware/config.py
+++ b/module/sources/vmware/config.py
@@ -382,6 +382,12 @@ class VMWareConfig(ConfigBase):
                          The same behavior also applies for VM disk sizes.""",
                          default_value=True
                          ),
+            ConfigOption("skip_host_nics",
+                         bool,
+                         description="""Skip creating or updating host physical nics in Netobx. Normal operation
+                         will maintain all phisical nics in netbox. This option will skip this part.""" ,
+                         default_value=False
+                         ),
 
             # removed settings
             ConfigOption("netbox_host_device_role",

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -1694,6 +1694,9 @@ class VMWareHandler(SourceBase):
         if len(host_custom_fields) > 0:
             host_data["custom_fields"] = host_custom_fields
 
+        if self.settings.skip_host_nics is True:
+            return
+
         # iterate over hosts virtual switches, needed to enrich data on physical interfaces
         self.network_data["vswitch"][name] = dict()
         for vswitch in grab(obj, "config.network.vswitch", fallback=list()):


### PR DESCRIPTION
We have issues today with the netbox sync, as it will mess with host physical networks.
Therefore I have introduced an config option to disable host network updates.