### PR TITLE
Clusters without sites or scopes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 
 # NetBox-Sync
 
+> [!CAUTION]
+> **Maintainer wanted - sunsetting this repository by 31.10.2025 [#474](https://github.com/bb-Ricardo/netbox-sync/issues/474)**
+
 This is a tool to sync data from different sources to a NetBox instance.
 
 Available source types:

--- a/module/netbox/__init__.py
+++ b/module/netbox/__init__.py
@@ -17,6 +17,8 @@ from module.netbox.object_classes import (
     NBTenant,
     NBSite,
     NBSiteGroup,
+    NBRegion,
+    NBLocation,
     NBVRF,
     NBVLAN,
     NBVLANList,

--- a/module/netbox/object_classes.py
+++ b/module/netbox/object_classes.py
@@ -1901,6 +1901,7 @@ class NBCluster(NetBoxObject):
             "scope_type": self.mapping.scopes_object_types(self.scopes),
             # currently only site is supported as a scope
             "scope_id": NetBoxObject,
+            "site": NBSite,
             "tags": NBTagList
         }
         super().__init__(*args, **kwargs)

--- a/module/netbox/object_classes.py
+++ b/module/netbox/object_classes.py
@@ -563,7 +563,6 @@ class NetBoxObject:
 
             # check data model to see how we have to parse the value
             defined_value_type = self.data_model.get(key)
-
             # value must be a string witch a certain max length
             if isinstance(defined_value_type, int):
                 if not isinstance(value, str):
@@ -587,7 +586,7 @@ class NetBoxObject:
 
                 # check if value is in defined list
                 elif value not in defined_value_type:
-                    log.error(f"Invalid data type for '{key}' (must be one of {defined_value_type}), got: '{value}'")
+                    log.error(f"this one. Invalid data type for '{key}' (must be one of {defined_value_type}), got: '{value}'")
                     continue
 
             # just check the type of the value
@@ -1890,7 +1889,7 @@ class NBCluster(NetBoxObject):
     def __init__(self, *args, **kwargs):
         self.mapping = NetBoxMappings()
         self.scopes = [
-            NBSite, NBSiteGroup
+            NBSite, NBSiteGroup, NBLocation, NBRegion
         ]
         self.data_model = {
             "name": 100,
@@ -1899,7 +1898,6 @@ class NBCluster(NetBoxObject):
             "tenant": NBTenant,
             "group": NBClusterGroup,
             "scope_type": self.mapping.scopes_object_types(self.scopes),
-            # currently only site is supported as a scope
             "scope_id": NetBoxObject,
             "site": NBSite,
             "tags": NBTagList

--- a/module/netbox/object_classes.py
+++ b/module/netbox/object_classes.py
@@ -659,7 +659,6 @@ class NetBoxObject:
                                                      max_len=self.data_model.get("slug"))
 
         # update all data items
-        log.debug2(f"Updating {self.name} '{display_name}' with data: {parsed_data.items()}")
         data_updated = False
         for key, new_value in parsed_data.items():
 
@@ -751,8 +750,7 @@ class NetBoxObject:
                 new_value_str = new_value_str.replace("\n", " ")
                 log.info(f"{self.name.capitalize()} '{display_name}' attribute '{key}' changed from "
                          f"'{current_value_str}' to '{new_value_str}'")
-            log.debug2(f"Updating {self.name} '{display_name}' attribute '{key}' from "
-                      f"'{current_value_str}' to '{new_value_str}'")
+            
             self.data[key] = new_value
             self.updated_items.append(key)
             data_updated = True
@@ -1873,6 +1871,7 @@ class NBCluster(NetBoxObject):
 
     def __init__(self, *args, **kwargs):
         self.mapping = NetBoxMappings()
+        # scope types allowed for clusters
         self.scopes = [
             NBSite, NBSiteGroup, NBLocation, NBRegion
         ]
@@ -1883,7 +1882,9 @@ class NBCluster(NetBoxObject):
             "tenant": NBTenant,
             "group": NBClusterGroup,
             "scope_type": self.mapping.scopes_object_types(self.scopes),
+            # supports scoped clusters
             "scope_id": NetBoxObject,
+            # supports pre4.2.0 clusters with site
             "site": NBSite,
             "tags": NBTagList
         }

--- a/module/netbox/object_classes.py
+++ b/module/netbox/object_classes.py
@@ -563,6 +563,7 @@ class NetBoxObject:
 
             # check data model to see how we have to parse the value
             defined_value_type = self.data_model.get(key)
+
             # value must be a string witch a certain max length
             if isinstance(defined_value_type, int):
                 if not isinstance(value, str):
@@ -586,7 +587,7 @@ class NetBoxObject:
 
                 # check if value is in defined list
                 elif value not in defined_value_type:
-                    log.error(f"this one. Invalid data type for '{key}' (must be one of {defined_value_type}), got: '{value}'")
+                    log.error(f"Invalid data type for '{key}' (must be one of {defined_value_type}), got: '{value}'")
                     continue
 
             # just check the type of the value
@@ -1272,21 +1273,6 @@ class NetBoxObject:
 
             if isinstance(this_site, dict):
                 return this_site.get("name")
-    
-    def get_scope_type(self, data=None):
-        this_data_set = data
-        if this_data_set is None:
-            this_data_set = self.data
-
-        return this_data_set.get("scope_type")
-    
-    def get_scope_id(self, data=None):
-        this_data_set = data
-        if this_data_set is None:
-            this_data_set = self.data
-
-        return this_data_set.get("scope_id")
-
 
 class NBObjectList(list):
     """
@@ -1884,7 +1870,6 @@ class NBCluster(NetBoxObject):
     primary_key = "name"
     secondary_key = "scope_id"
     prune = False
-    # include_secondary_key_if_present = True
 
     def __init__(self, *args, **kwargs):
         self.mapping = NetBoxMappings()
@@ -1906,21 +1891,10 @@ class NBCluster(NetBoxObject):
 
     def update(self, data=None, read_from_netbox=False, source=None):
 
-        # Add adaption for change in NetBox 4.2.0 Device model
-        # if version.parse(self.inventory.netbox_api_version) >= version.parse("4.2.0"):
-        #     if data.get("site") is not None:
-        #         data["scope_id"] = data.get("site")
-        #         data["scope_type"] = "dcim.site"
-        #         del data["site"]
-
-        #     if data.get("scope_id") is not None:
-        #         data["scope_type"] = "dcim.site"
-
         super().update(data=data, read_from_netbox=read_from_netbox, source=source)
 
     def resolve_relations(self):
         log.debug2(f"Resolving relations for {self.name} '{self.get_display_name()}'")
-        # self.resolve_scoped_relations("scope_id", "scope_type")
         super().resolve_relations()
 
 

--- a/module/netbox/object_classes.py
+++ b/module/netbox/object_classes.py
@@ -1273,19 +1273,19 @@ class NetBoxObject:
             if isinstance(this_site, dict):
                 return this_site.get("name")
     
-    # def get_scope_type(self, data=None):
-    #     this_data_set = data
-    #     if this_data_set is None:
-    #         this_data_set = self.data
+    def get_scope_type(self, data=None):
+        this_data_set = data
+        if this_data_set is None:
+            this_data_set = self.data
 
-    #     return this_data_set.get("scope_type")
+        return this_data_set.get("scope_type")
     
-    # def get_scope_id(self, data=None):
-    #     this_data_set = data
-    #     if this_data_set is None:
-    #         this_data_set = self.data
+    def get_scope_id(self, data=None):
+        this_data_set = data
+        if this_data_set is None:
+            this_data_set = self.data
 
-    #     return this_data_set.get("scope_id")
+        return this_data_set.get("scope_id")
 
 
 class NBObjectList(list):

--- a/module/netbox/object_classes.py
+++ b/module/netbox/object_classes.py
@@ -1272,6 +1272,20 @@ class NetBoxObject:
 
             if isinstance(this_site, dict):
                 return this_site.get("name")
+    
+    # def get_scope_type(self, data=None):
+    #     this_data_set = data
+    #     if this_data_set is None:
+    #         this_data_set = self.data
+
+    #     return this_data_set.get("scope_type")
+    
+    # def get_scope_id(self, data=None):
+    #     this_data_set = data
+    #     if this_data_set is None:
+    #         this_data_set = self.data
+
+    #     return this_data_set.get("scope_id")
 
 
 class NBObjectList(list):
@@ -1424,39 +1438,39 @@ class NBTenant(NetBoxObject):
         super().__init__(*args, **kwargs)
 
 
-# class NBLocation(NetBoxObject):
-#     name = "location"
-#     api_path = "dcim/locations"
-#     object_type = "dcim.location"
-#     primary_key = "name"
-#     prune = False
-#     read_only = True
-#
-#     def __init__(self, *args, **kwargs):
-#         self.data_model = {
-#             "name": 100,
-#             "slug": 100,
-#             "site": NBSite,
-#             "tags": NBTagList
-#         }
-#         super().__init__(*args, **kwargs)
-#
-#
-# class NBRegion(NetBoxObject):
-#     name = "region"
-#     api_path = "dcim/regions"
-#     object_type = "dcim.region"
-#     primary_key = "name"
-#     prune = False
-#     read_only = True
-#
-#     def __init__(self, *args, **kwargs):
-#         self.data_model = {
-#             "name": 100,
-#             "slug": 100,
-#             "tags": NBTagList
-#         }
-#         super().__init__(*args, **kwargs)
+class NBLocation(NetBoxObject):
+    name = "location"
+    api_path = "dcim/locations"
+    object_type = "dcim.location"
+    primary_key = "name"
+    prune = False
+    read_only = True
+
+    def __init__(self, *args, **kwargs):
+        self.data_model = {
+            "name": 100,
+            "slug": 100,
+            "site": NBSite,
+            "tags": NBTagList
+        }
+        super().__init__(*args, **kwargs)
+
+
+class NBRegion(NetBoxObject):
+    name = "region"
+    api_path = "dcim/regions"
+    object_type = "dcim.region"
+    primary_key = "name"
+    prune = False
+    read_only = True
+
+    def __init__(self, *args, **kwargs):
+        self.data_model = {
+            "name": 100,
+            "slug": 100,
+            "tags": NBTagList
+        }
+        super().__init__(*args, **kwargs)
 
 
 class NBSite(NetBoxObject):

--- a/module/sources/common/source_base.py
+++ b/module/sources/common/source_base.py
@@ -8,6 +8,7 @@
 #  repository or visit: <https://opensource.org/licenses/MIT>.
 
 import re
+from typing import Union,Optional
 
 from ipaddress import ip_interface, ip_address, IPv6Address, IPv4Address, IPv6Network, IPv4Network
 from packaging import version
@@ -179,7 +180,7 @@ class SourceBase:
 
         return return_data
 
-    def return_longest_matching_prefix_for_ip(self, ip_to_match=None, site_name=None) -> NBPrefix|None:
+    def return_longest_matching_prefix_for_ip(self, ip_to_match=None, site_name=None) -> Optional[NBPrefix]:
         """
         This is a lazy approach to find the longest matching prefix to an IP address.
         If site_name is set only IP prefixes from that site are matched.
@@ -716,7 +717,7 @@ class SourceBase:
 
         return data_to_update
 
-    def add_vlan_group(self, vlan_data, vlan_site, vlan_cluster) -> NBVLAN | dict:
+    def add_vlan_group(self, vlan_data, vlan_site, vlan_cluster) -> Union[NBVLAN ,dict]:
         """
         This function will try to find a matching VLAN group according to the settings.
         Name matching will take precedence over ID matching. First match wins.

--- a/module/sources/vmware/config.py
+++ b/module/sources/vmware/config.py
@@ -143,6 +143,24 @@ class VMWareConfig(ConfigBase):
                                              description="""Same as cluster site but on host level.
                                              If unset it will fall back to cluster_site_relation""",
                                              config_example="nyc02.* = New York, ffm01.* = Frankfurt"),
+                                ConfigOption("cluster_scope_type_relation", 
+                                             str,
+                                             description="""This option defines the scope type for a cluster.
+                                             The scope type can be 'site', 'site-group', 'location' or 'region'.
+                                             This is done with a comma separated key = value list.
+                                               key: defines a cluster name as regex
+                                               value: defines the NetBox scope type name (use quotes if name contains commas)
+                                             """,
+                                             config_example="Cluster_NYC = site, Cluster_FFM = sitegroup, Cluster_BER = location"),
+                                ConfigOption("cluster_scope_id_relation",
+                                             str,
+                                             description="""This option defines the scope id for a cluster.
+                                             The scope id is the NetBox ID of the scope type.
+                                             This is done with a comma separated key = value list.
+                                               key: defines a cluster name as regex
+                                               value: defines the NetBox scope id (use quotes if name contains commas)
+                                             """,
+                                             config_example="Cluster_NYC = New York, Cluster_FFM.* = Data Centers, Cluster_BER = Building 1"),
                                 ConfigOption("cluster_tenant_relation",
                                              str,
                                              description="""\

--- a/module/sources/vmware/config.py
+++ b/module/sources/vmware/config.py
@@ -149,6 +149,7 @@ class VMWareConfig(ConfigBase):
                                              The scope type can be 'dcim.site', 'dcim.sitegroup', 'dcim.location' or 'dcim.region'.
                                              This is done with a comma separated key = value list.
                                              Can be set to "<NONE>" to not assign a scope type.
+                                             Note: this does not remove scope types from existing clusters in NetBox.
                                                key: defines a cluster name as regex
                                                value: defines the NetBox scope type name (use quotes if name contains commas)
                                              """,

--- a/module/sources/vmware/config.py
+++ b/module/sources/vmware/config.py
@@ -148,6 +148,7 @@ class VMWareConfig(ConfigBase):
                                              description="""This option defines the scope type for a cluster.
                                              The scope type can be 'dcim.site', 'dcim.sitegroup', 'dcim.location' or 'dcim.region'.
                                              This is done with a comma separated key = value list.
+                                             Can be set to "<NONE>" to not assign a scope type.
                                                key: defines a cluster name as regex
                                                value: defines the NetBox scope type name (use quotes if name contains commas)
                                              """,
@@ -157,6 +158,7 @@ class VMWareConfig(ConfigBase):
                                              description="""This option defines the scope id for a cluster.
                                              The scope id is the NetBox ID of the scope type.
                                              This is done with a comma separated key = value list.
+                                             To be used in combination with the 'cluster_scope_type_relation'.
                                                key: defines a cluster name as regex
                                                value: defines the NetBox scope id (use quotes if name contains commas)
                                              """,

--- a/module/sources/vmware/config.py
+++ b/module/sources/vmware/config.py
@@ -146,12 +146,12 @@ class VMWareConfig(ConfigBase):
                                 ConfigOption("cluster_scope_type_relation", 
                                              str,
                                              description="""This option defines the scope type for a cluster.
-                                             The scope type can be 'site', 'site-group', 'location' or 'region'.
+                                             The scope type can be 'dcim.site', 'dcim.sitegroup', 'dcim.location' or 'dcim.region'.
                                              This is done with a comma separated key = value list.
                                                key: defines a cluster name as regex
                                                value: defines the NetBox scope type name (use quotes if name contains commas)
                                              """,
-                                             config_example="Cluster_NYC = site, Cluster_FFM = sitegroup, Cluster_BER = location"),
+                                             config_example="Cluster_NYC = dcim.site, Cluster_FFM = dcim.sitegroup, Cluster_BER = dcim.location"),
                                 ConfigOption("cluster_scope_id_relation",
                                              str,
                                              description="""This option defines the scope id for a cluster.

--- a/module/sources/vmware/config.py
+++ b/module/sources/vmware/config.py
@@ -163,7 +163,7 @@ class VMWareConfig(ConfigBase):
                                                key: defines a cluster name as regex
                                                value: defines the NetBox scope id (use quotes if name contains commas)
                                              """,
-                                             config_example="Cluster_NYC = New York, Cluster_FFM.* = Data Centers, Cluster_BER = Building 1"),
+                                             config_example="Cluster_NYC = 1, Cluster_FFM.* = 2, Cluster_BER = 7"),
                                 ConfigOption("cluster_tenant_relation",
                                              str,
                                              description="""\

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -2180,10 +2180,13 @@ class VMWareHandler(SourceBase):
         platform = get_string_or_none(grab(obj, "guest.guestFullName", fallback=platform))
 
         # extract prettyName from extraConfig exposed by guest tools
-        extra_config = [x.value for x in grab(obj, "config.extraConfig", fallback=[])
-                        if x.key == "guestOS.detailed.data"]
-        if len(extra_config) > 0:
-            pretty_name = [x for x in quoted_split(extra_config[0].replace("' ", "', ")) if x.startswith("prettyName")]
+        extra_config = {x.key: x.value for x in grab(obj, "config.extraConfig", fallback=[])
+                        if x.key in ["guestOS.detailed.data", "guestInfo.detailed.data"]}
+
+        # first try 'guestInfo.detailed.data' and then 'guestOS.detailed.data'
+        detailed_data = extra_config.get("guestInfo.detailed.data") or extra_config.get("guestOS.detailed.data")
+        if isinstance(detailed_data, str):
+            pretty_name = [x for x in quoted_split(detailed_data.replace("' ", "', ")) if x.startswith("prettyName")]
             if len(pretty_name) > 0:
                 platform = pretty_name[0].replace("prettyName='","")
 

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -1388,8 +1388,9 @@ class VMWareHandler(SourceBase):
         }
 
         if version.parse(self.inventory.netbox_api_version) >= version.parse("4.2.0"):
-            data["scope_id"] = {"name": site_name}
-            data["scope_type"] = "dcim.site"
+            if site_name is not None:
+                data["scope_id"] = {"name": site_name}
+                data["scope_type"] = "dcim.site"
         else:
             data["site"] = {"name": site_name}
 

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -2186,9 +2186,15 @@ class VMWareHandler(SourceBase):
         # first try 'guestInfo.detailed.data' and then 'guestOS.detailed.data'
         detailed_data = extra_config.get("guestInfo.detailed.data") or extra_config.get("guestOS.detailed.data")
         if isinstance(detailed_data, str):
-            pretty_name = [x for x in quoted_split(detailed_data.replace("' ", "', ")) if x.startswith("prettyName")]
-            if len(pretty_name) > 0:
-                platform = pretty_name[0].replace("prettyName='","")
+            detailed_data_dict = dict()
+            for detailed_data_item in quoted_split(detailed_data.replace("' ", "', ")):
+                detailed_data_key, detailed_data_value = detailed_data_item.split("=")
+                detailed_data_dict[detailed_data_key] = detailed_data_value.strip("'")
+            if len(detailed_data_dict.get("prettyName","")) > 0:
+                platform = detailed_data_dict.get("prettyName")
+            if detailed_data_dict.get("prettyName").lower() == "linux" and \
+                    detailed_data_dict.get("distroVersion") not in platform:
+                platform = f'{platform} {detailed_data_dict.get("distroVersion")}'
 
         if platform is not None:
             platform = self.get_object_relation(platform, "vm_platform_relation", fallback=platform)

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -484,9 +484,9 @@ class VMWareHandler(SourceBase):
                 # set deault site name if no relation was found
                 if site_name is None:
                     site_name = self.site_name
-                    log.debug(f"No site relation for {type(object_name)}: '{object_name}' found, using default site '{site_name}'")
+                    log.debug2(f"No site relation for {type(object_name)}: '{object_name}' found, using default site '{site_name}'")
 
-        # set default site name
+        # set default site name for devices
         if site_name is None and object_type == NBDevice:
             site_name = self.site_name
             log.debug(f"No site relation for '{object_name}' found, using default site '{site_name}'")
@@ -1477,16 +1477,12 @@ class VMWareHandler(SourceBase):
         log.debug(f"Cluster '{name}' passes include and exclude filters. Continuing.")
 
         scope_type = self.get_scope_type(NBCluster, full_cluster_name)
-        log.debug(f"Cluster '{full_cluster_name}' has scope type '{scope_type}' of type {type(scope_type)}.")
         if scope_type is None:
             scope_type = self.get_scope_type(NBCluster, name)
-            log.debug(f"Cluster '{full_cluster_name}' has scope type '{scope_type}' of type {type(scope_type)}.")
-        site_name = self.get_site_name(NBCluster, full_cluster_name)
-        log.debug(f"Cluster '{full_cluster_name}' has site name '{site_name}' of type {type(site_name)}.")
-
-        scope_id = self.get_scope_id(NBCluster, full_cluster_name)
-        log.debug(f"Cluster '{full_cluster_name}' has scope id '{scope_id}' of type {type(scope_id)}.")
         
+        site_name = self.get_site_name(NBCluster, full_cluster_name)
+
+        scope_id = self.get_scope_id(NBCluster, full_cluster_name)        
         if scope_id is None:
             scope_id = self.get_scope_id(NBCluster, name)
         log.debug(f"Cluster '{full_cluster_name}' has scope id '{scope_id}' of type {type(scope_id)}.")
@@ -1501,7 +1497,7 @@ class VMWareHandler(SourceBase):
             # four scope types here (dcim.site, dcim.location, dcim.region, dcim.sitegroup)
             if scope_type is not None:
                 data["scope_type"] = scope_type
-                data["scope_id"] = {"name": scope_id}
+                data["scope_id"] = scope_id
                 log.debug(f"Cluster '{full_cluster_name}' (or {name}) has scope type '{scope_type}' "
                           f"and scope id '{scope_id}'.")
             elif site_name is not None:
@@ -1513,6 +1509,8 @@ class VMWareHandler(SourceBase):
             # old verison has site only (# TODO: required??) --> optional (tested in netbox versions 4.1.11 and 3.7.1)
             if site_name is not None:
                 data["site"] = {"name": site_name}
+
+        log.debug(f"Cluster '{full_cluster_name}' (or {name}) has data items '{data.items()}'.")
 
         tenant_name = self.get_object_relation(full_cluster_name, "cluster_tenant_relation")
         if tenant_name is not None:
@@ -1563,8 +1561,10 @@ class VMWareHandler(SourceBase):
             cluster_object = fallback_cluster_object
 
         if cluster_object is not None:
+            # log.debug(f"1st The data items are {data.items()} for cluster '{name}'")
             cluster_object.update(data=data, source=self)
         else:
+            # log.debug(f"1st (alternative) The data items are {data.items()} for cluster '{name}'")
             cluster_object = self.inventory.add_update_object(NBCluster, data=data, source=self)
 
         self.add_object_to_cache(obj, cluster_object)

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -540,6 +540,11 @@ class VMWareHandler(SourceBase):
         if type(scope_type) is not str:
             log.debug(f"scope_type is type: {type(scope_type)}, not str")
             return None
+
+        if scope_type == "<NONE>":
+            log.debug(f"Scope type for {object_type.name} '{object_name}' is set to None")
+            return None
+        
         log.debug(f"Returning scope type '{scope_type}' for {object_type.name} '{object_name}'. End of method.")
         return scope_type
 

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -469,7 +469,7 @@ class VMWareHandler(SourceBase):
         if object_type not in [NBCluster, NBDevice]:
             raise ValueError(f"Object must be a '{NBCluster.name}' or '{NBDevice.name}'.")
 
-        log.debug(f"Trying to find site name for {object_type.name} '{object_name}'")
+        log.debug2(f"Trying to find site name for {object_type.name} '{object_name}'")
 
         # check if site was provided in config
         relation_name = "host_site_relation" if object_type == NBDevice else "cluster_site_relation"
@@ -525,24 +525,28 @@ class VMWareHandler(SourceBase):
         if object_type != NBCluster:
             raise ValueError(f"Object type must be '{NBCluster.name}'.")
         
+        # get scope type from relation config
         relation_name = "cluster_scope_type_relation"
         scope_type = self.get_object_relation(object_name, relation_name)
         log.debug(f"Retrieved scope type '{scope_type}' for {object_type.name} '{object_name}' from relation '{relation_name}'.")
         
+        # if the scope_type is a list, use the first element
         if scope_type is not None and type(scope_type) is list:
             scope_type_list = scope_type
             scope_type = scope_type_list[0] if len(scope_type_list) > 0 else None
             log.debug(f"Scope type for {object_type.name} '{object_name}' is a list, using first element: '{scope_type}'")
 
+        # if scope_type is not a str, return None
         if type(scope_type) is not str:
             log.debug(f"scope_type is type: {type(scope_type)}, not str")
             return None
 
+        # set scope_type to None if it is configured as "<NONE>"
         if scope_type == "<NONE>":
             log.debug(f"Scope type for {object_type.name} '{object_name}' is set to None")
             return None
         
-        log.debug(f"Returning scope type '{scope_type}' for {object_type.name} '{object_name}'. End of method.")
+        log.debug2(f"Returning scope type '{scope_type}' for {object_type.name} '{object_name}'.")
         return scope_type
 
     def get_scope_id(self, object_type, object_name):
@@ -567,21 +571,19 @@ class VMWareHandler(SourceBase):
         if object_type != NBCluster:
             raise ValueError(f"Object type must be '{NBCluster.name}'.")
 
-
+        # get scope id from relation config
         relation_name = "cluster_scope_id_relation"
-        
         scope_id = self.get_object_relation(object_name, relation_name)
 
+        # return None if scope_id is None or not a string
         if scope_id is None:
-            scope_id = object_name
-            if scope_id is None:
-                log.debug(f"No scope id found for {object_name}.") 
-                return None
+            log.debug(f"No scope id found for {object_name}.") 
+            return None
         if type(scope_id) is not str:
             log.debug(f"scope_id is type: {type(scope_id)}, not str")
             return None
         
-        log.debug(f"Retrieved scope id '{scope_id}' for {object_type.name} '{object_name}' from relation '{relation_name}'. End of method.")
+        log.debug2(f"Retrieved scope id '{scope_id}' for {object_type.name} '{object_name}' from relation '{relation_name}'. End of method.")
 
         return scope_id
     
@@ -1472,8 +1474,9 @@ class VMWareHandler(SourceBase):
                                       self.settings.cluster_include_filter,
                                       self.settings.cluster_exclude_filter) is False:
             return
-        log.debug(f"Cluster '{name}' passes include and exclude filters. Continuing.")
+        log.debug2(f"Cluster '{name}' passes include and exclude filters. Continuing.")
 
+        # get scope type and id, or site name
         scope_type = self.get_scope_type(NBCluster, full_cluster_name)
         if scope_type is None:
             scope_type = self.get_scope_type(NBCluster, name)
@@ -1504,7 +1507,7 @@ class VMWareHandler(SourceBase):
             else:
                 log.debug(f"Cluster '{full_cluster_name}' has no scope type or scope id.")
         else:
-            # set site_name in the pre-4.2.0 NetBox versions is one is found
+            # set site_name in the pre-4.2.0 NetBox versions if one is found
             if site_name is not None:
                 data["site"] = {"name": site_name}
 

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -498,10 +498,7 @@ class VMWareHandler(SourceBase):
             site_name = None
             log.debug2(f"Site relation for '{object_name}' set to None")
 
-        if site_name is None and object_type == NBCluster:
-            log.debug(f"No site relation for {object_type.name} '{object_name}' found")
-
-        log.debug(f"Returning site name '{site_name}' for {object_type.name} '{object_name}'. End of method.")
+        log.debug2(f"Returning site name '{site_name}' for {object_type.name} '{object_name}'.")
 
         return site_name
     
@@ -574,12 +571,6 @@ class VMWareHandler(SourceBase):
         relation_name = "cluster_scope_id_relation"
         
         scope_id = self.get_object_relation(object_name, relation_name)
-        
-        # object_instance = self.inventory.get_by_data(object_type, data={"name": object_name})
-
-        # if object_instance is None:
-        #     log.debug2(f"No {object_type.name} found with name '{object_name}'.")
-        #     return None
 
         if scope_id is None:
             scope_id = object_name
@@ -1501,7 +1492,7 @@ class VMWareHandler(SourceBase):
         }
 
         if version.parse(self.inventory.netbox_api_version) >= version.parse("4.2.0"):
-            # four scope types here (dcim.site, dcim.location, dcim.region, dcim.sitegroup)
+            # set the scope type and id if they are defined
             if scope_type is not None:
                 data["scope_type"] = scope_type
                 data["scope_id"] = scope_id
@@ -1513,7 +1504,7 @@ class VMWareHandler(SourceBase):
             else:
                 log.debug(f"Cluster '{full_cluster_name}' has no scope type or scope id.")
         else:
-            # old verison has site only (# TODO: required??) --> optional (tested in netbox versions 4.1.11 and 3.7.1)
+            # set site_name in the pre-4.2.0 NetBox versions is one is found
             if site_name is not None:
                 data["site"] = {"name": site_name}
 
@@ -1568,10 +1559,8 @@ class VMWareHandler(SourceBase):
             cluster_object = fallback_cluster_object
 
         if cluster_object is not None:
-            # log.debug(f"1st The data items are {data.items()} for cluster '{name}'")
             cluster_object.update(data=data, source=self)
         else:
-            # log.debug(f"1st (alternative) The data items are {data.items()} for cluster '{name}'")
             cluster_object = self.inventory.add_update_object(NBCluster, data=data, source=self)
 
         self.add_object_to_cache(obj, cluster_object)

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -2188,11 +2188,14 @@ class VMWareHandler(SourceBase):
         if isinstance(detailed_data, str):
             detailed_data_dict = dict()
             for detailed_data_item in quoted_split(detailed_data.replace("' ", "', ")):
+                if "=" not in detailed_data_item:
+                    continue
+
                 detailed_data_key, detailed_data_value = detailed_data_item.split("=")
                 detailed_data_dict[detailed_data_key] = detailed_data_value.strip("'")
             if len(detailed_data_dict.get("prettyName","")) > 0:
                 platform = detailed_data_dict.get("prettyName")
-            if detailed_data_dict.get("prettyName").lower() == "linux" and \
+            if detailed_data_dict.get("familyName", "").lower() == "linux" and \
                     detailed_data_dict.get("distroVersion") not in platform:
                 platform = f'{platform} {detailed_data_dict.get("distroVersion")}'
 

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -474,12 +474,14 @@ class VMWareHandler(SourceBase):
 
         site_name = self.get_object_relation(object_name, relation_name)
 
-        if object_type == NBDevice: # and site_name is None:
+        # check if cluster is in a different site than the host and override the site name if so
+        if object_type == NBDevice:
             site_name = self.get_site_name(NBCluster, cluster_name)
             if site_name is not None:
-                log.debug2(f"Found a matching cluster site for {object_name}, using site '{site_name}'")
+                log.debug2(f"Found a matching cluster site for {object_name}, using site '{site_name}'. Overriding host site relation '{relation_name}'")
             else:
                 site_name = self.get_object_relation(object_name, relation_name)
+                # set deault site name if no relation was found
                 if site_name is None:
                     site_name = self.site_name
                     log.debug(f"No site relation for {type(object_name)}: '{object_name}' found, using default site '{site_name}'")
@@ -527,19 +529,6 @@ class VMWareHandler(SourceBase):
         relation_name = "cluster_scope_type_relation"
         scope_type = self.get_object_relation(object_name, relation_name)
         log.debug(f"Retrieved scope type '{scope_type}' for {object_type.name} '{object_name}' from relation '{relation_name}'.")
-        
-        # object_instance = self.inventory.get_by_data(object_type, data={"name": object_name})
-        # log.debug(f"Retrieved object instance for {object_type.name} '{object_name}'")
-
-        # if object_instance is None:
-        #     log.debug(f"No {object_type.name} found with name '{object_name}'.")
-        #     return None
-        
-        # if scope_type is None:
-        #     scope_type = object_instance.data_model.get("scope_type")
-        #     if scope_type is None:
-        #         log.debug(f"No scope type found for {object_name}.")
-        #         return None
         
         if scope_type is not None and type(scope_type) is list:
             scope_type_list = scope_type

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -1515,6 +1515,9 @@ class VMWareHandler(SourceBase):
                 data["scope_id"] = {"name": scope_id}
                 log.debug(f"Cluster '{full_cluster_name}' (or {name}) has scope type '{scope_type}' "
                           f"and scope id '{scope_id}'.")
+            elif site_name is not None:
+                data["scope_type"] = "dcim.site"
+                data["scope_id"] = {"name": site_name}
             else:
                 log.debug(f"Cluster '{full_cluster_name}' has no scope type or scope id.")
         else:

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -62,6 +62,8 @@ class VMWareHandler(SourceBase):
         NBDeviceRole,
         NBSite,
         NBSiteGroup,
+        NBLocation,
+        NBRegion,
         NBCluster,
         NBDevice,
         NBVM,


### PR DESCRIPTION
Further to #468, these changes allow clusters to have no site or scope type, or different scope types to be used (other than site). Maintains Netbox pre-4.2.0 compatibility.
