### PR TITLE
feat: GA build and push docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,86 @@
+name: Build netbox-sync docker image
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+    branches:
+      - development
+    paths:
+      - module/**
+      - netbox-sync.py
+      - requirements.txt
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Lower case docker image name
+        id: docker_image
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ github.repository }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta GitHub Container Registry
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ steps.docker_image.outputs.lowercase }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+
+      - name: Build and push with tags - ${{ steps.meta.outputs.tags }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Docker hub meta
+        id: meta_dhub
+        uses: docker/metadata-action@v5
+        with:
+          images: docker.io/bbricardo/${{ steps.docker_image.outputs.lowercase }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+
+      - name: Build and push with tags - ${{ steps.meta_dhub.outputs.tags }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta_dhub.outputs.tags }}
+          labels: ${{ steps.meta_dhub.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm AS builder
+FROM python:3.11-slim AS builder
 
 COPY requirements.txt .
 
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git && \
     $VENV/bin/pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git && \
     find $VENV -type d -name "__pycache__" -print0 | xargs -0 -n1 rm -rf
 
-FROM python:3.11-slim-bookworm AS netbox-sync
+FROM python:3.11-slim AS netbox-sync
 
 ARG VENV=/opt/netbox-sync/venv
 


### PR DESCRIPTION
Closes #479

Please do note that you should add this secrets before merge: https://github.com/rizlas/netbox-sync/blob/development/.github/workflows/docker-image.yml#L67-L68

The Github action will build and push on both Github Container and Docker hub registries. It will be triggered on:

  * **Tag creation** → build and push image tagged with the **release name** and `latest`
  * **Push to `development` branch** → build and push image tagged with the branch name (`development`)
  * **Manual trigger (workflow_dispatch)** → build and push image tagged with the branch name
