### PR TITLE
pin pycares to 4.0.0, newer versions are incompatible with aiodns 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ wheel
 requests==2.32.3
 pyvmomi==8.0.2.0.1
 aiodns==3.0.0
+pycares==4.0.0
 pyyaml==6.0.1


### PR DESCRIPTION
using the most recent pycares version results in the following exception:

```
Traceback (most recent call last):
  File "/opt/netbox-sync/./netbox-sync.py", line 146, in <module>
    main()
  File "/opt/netbox-sync/./netbox-sync.py", line 117, in main
    inventory.query_ptr_records_for_all_ips()
  File "/opt/netbox-sync/module/netbox/inventory.py", line 431, in query_ptr_records_for_all_ips
    records = perform_ptr_lookups(data.get("ips"), data.get("servers"))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/netbox-sync/module/common/support.py", line 75, in perform_ptr_lookups
    results = loop.run_until_complete(queue)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/opt/netbox-sync/module/common/support.py", line 105, in reverse_lookup
    response = await resolver.gethostbyaddr(ip)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/netbox-sync/.venv/lib/python3.11/site-packages/aiodns/__init__.py", line 102, in gethostbyaddr
    self._channel.gethostbyaddr(name, cb)
TypeError: Channel.gethostbyaddr() takes 2 positional arguments but 3 were given
```

this PR fixes that by using a pycares version from around the time aiodns 3.0.0 was released.