### PR TITLE
Fix distroVersion if unknown version in VMWARE

### DIFF
--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -2196,9 +2196,14 @@ class VMWareHandler(SourceBase):
                 detailed_data_dict[detailed_data_key] = detailed_data_value.strip("'")
             if len(detailed_data_dict.get("prettyName","")) > 0:
                 platform = detailed_data_dict.get("prettyName")
-            if detailed_data_dict.get("familyName", "").lower() == "linux" and \
-                    detailed_data_dict.get("distroVersion") not in platform:
-                platform = f'{platform} {detailed_data_dict.get("distroVersion")}'
+                
+            distro_version = detailed_data_dict.get("distroVersion")
+            if detailed_data_dict.get("familyName", "").lower() == "linux" and distro_version:
+                if distro_version not in platform:
+                    platform = f'{platform} {distro_version}'
+        if platform is not None:
+            platform = self.get_object_relation(platform, "vm_platform_relation", fallback=platform)
+
 
         if platform is not None:
             platform = self.get_object_relation(platform, "vm_platform_relation", fallback=platform)


### PR DESCRIPTION
 File "/opt/netbox-sync/module/sources/vmware/connection.py", line 2200, in add_virtual_machine

detailed_data_dict.get("distroVersion") not in platform:

TypeError: 'in <string>' requires string as left operand, not NoneType 

Fixes this error, this seemed to be when a OS version is not known in VMWare.