### PR TITLE
Skip prune on source failure

### DIFF
--- a/module/netbox/config.py
+++ b/module/netbox/config.py
@@ -128,7 +128,15 @@ class NetBoxConfig(ConfigBase):
             ConfigOption("cache_directory_location",
                          str,
                          description="The location of the directory where the cache files should be stored",
-                         default_value="cache")
+                         default_value="cache"),
+
+            ConfigOption("skip_prune_on_source_failure",
+                        bool,
+                        description="""Safety switch: If any enabled source fails (init/connect/query),
+                        pruning will be skipped for this run to prevent mass orphaning/deletions
+                        during temporary source outages.
+                        """,
+                        default_value=True)
         ]
 
         super().__init__()

--- a/netbox-sync.py
+++ b/netbox-sync.py
@@ -124,7 +124,23 @@ def main():
     # update data in NetBox
     nb_handler.update_instance()
 
-    # prune orphaned objects from NetBox
+# prune orphaned objects from NetBox (safe-guard)
+failed_enabled_sources = [
+    s for s in inventory.source_list
+    if getattr(getattr(s, "settings", None), "enabled", False) is True
+    and getattr(s, "init_successful", False) is False
+]
+
+if nb_handler.settings.prune_enabled and \
+   getattr(nb_handler.settings, "skip_prune_on_source_failure", True) and \
+   len(failed_enabled_sources) > 0:
+
+    failed_names = ", ".join([getattr(s, "name", "<unknown>") for s in failed_enabled_sources])
+    log.warning(
+        f"Skipping prune because {len(failed_enabled_sources)} enabled source(s) failed init: {failed_names}"
+    )
+
+else:
     nb_handler.prune_data()
 
     # delete tags which are not used anymore

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -109,6 +109,9 @@ host_fqdn = netbox.example.com
 ;;; a sources name. Sources can be defined multiple times to represent different sources.
 ;;;
 
+; Safety: If any enabled source fails, skip pruning for this run
+;skip_prune_on_source_failure = True
+
 [source/my-vcenter-example]
 
 ; Defines if this source is enabled or not
@@ -404,9 +407,6 @@ password = super-secret
 ; value of 4000 megabyte. If set to false 4GB of RAM will be reported as 4096MB. The same
 ; behavior also applies for VM disk sizes.
 ;vm_disk_and_ram_in_decimal = True
-
-; Safety: If any enabled source fails, skip pruning for this run
-;skip_prune_on_source_failure = True
 
 [source/my-redfish-example]
 

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -405,6 +405,9 @@ password = super-secret
 ; behavior also applies for VM disk sizes.
 ;vm_disk_and_ram_in_decimal = True
 
+; Safety: If any enabled source fails, skip pruning for this run
+;skip_prune_on_source_failure = True
+
 [source/my-redfish-example]
 
 ; Defines if this source is enabled or not


### PR DESCRIPTION
Problem

When a source (for example vCenter) is temporarily unavailable due to network issues, authentication errors, or maintenance, netbox-sync may fail to initialize that source and receive an empty inventory.
If pruning is enabled, this can incorrectly mark a large number of existing objects (VMs, interfaces, IP addresses) as orphaned and prune them from NetBox, even though the source outage is temporary.

Solution

This pull request introduces a safety guard that skips the prune step when one or more enabled sources fail to initialize during a sync run.
Pruning is only executed when enabled sources are successfully initialized, preventing accidental mass orphaning or deletions caused by transient source failures.

Behavior

No change when all enabled sources initialize successfully; pruning works as before.

If any enabled source fails to initialize, the prune step is skipped for that run and a warning is logged.

Pruning resumes automatically on the next successful run.

Configuration

A new optional configuration flag is added under the [netbox] section:

`skip_prune_on_source_failure = True`


When enabled, pruning is skipped if at least one enabled source fails initialization.

Rationale

This change is intentionally safety-first and conservative. It does not alter normal prune behavior during healthy runs and helps protect NetBox data integrity during temporary source outages.