### PR TITLE
fix pycares build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt .
 ARG VENV=/opt/netbox-sync/venv
 
 # Install dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends git && \
+RUN apt-get update && apt-get install -y --no-install-recommends git gcc libc-dev && \
     rm -rf /var/lib/apt/lists/* && \
     python3 -m venv $VENV && \
     $VENV/bin/python3 -m pip install --upgrade pip && \


### PR DESCRIPTION
since #487 is merged, the Docker build breaks: 

```

#7 24.04 Requirement already satisfied: pip in /opt/netbox-sync/venv/lib/python3.11/site-packages (24.0)
#7 24.24 Collecting pip
#7 24.36   Downloading pip-26.0.1-py3-none-any.whl.metadata (4.7 kB)
#7 24.38 Downloading pip-26.0.1-py3-none-any.whl (1.8 MB)
#7 24.52    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 MB 13.0 MB/s eta 0:00:00
#7 24.59 Installing collected packages: pip
#7 24.59   Attempting uninstall: pip
#7 24.59     Found existing installation: pip 24.0
#7 24.64     Uninstalling pip-24.0:
#7 24.65       Successfully uninstalled pip-24.0
#7 25.72 Successfully installed pip-26.0.1
#7 26.76 Collecting packaging (from -r requirements.txt (line 1))
#7 26.92   Downloading packaging-26.0-py3-none-any.whl.metadata (3.3 kB)
#7 26.96 Collecting urllib3==2.2.2 (from -r requirements.txt (line 2))
#7 26.98   Downloading urllib3-2.2.2-py3-none-any.whl.metadata (6.4 kB)
#7 27.03 Collecting wheel (from -r requirements.txt (line 3))
#7 27.04   Downloading wheel-0.46.3-py3-none-any.whl.metadata (2.4 kB)
#7 27.08 Collecting requests==2.32.3 (from -r requirements.txt (line 4))
#7 27.09   Downloading requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
#7 27.12 Collecting pyvmomi==8.0.2.0.1 (from -r requirements.txt (line 5))
#7 27.14   Downloading pyvmomi-8.0.2.0.1.tar.gz (852 kB)
#7 27.21      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 852.2/852.2 kB 13.3 MB/s  0:00:00
#7 27.33   Installing build dependencies: started
#7 28.40   Installing build dependencies: finished with status 'done'
#7 28.40   Getting requirements to build wheel: started
#7 28.81   Getting requirements to build wheel: finished with status 'done'
#7 28.81   Preparing metadata (pyproject.toml): started
#7 29.02   Preparing metadata (pyproject.toml): finished with status 'done'
#7 29.05 Collecting aiodns==3.0.0 (from -r requirements.txt (line 6))
#7 29.07   Downloading aiodns-3.0.0-py3-none-any.whl.metadata (3.5 kB)
#7 29.19 Collecting pycares==4.0.0 (from -r requirements.txt (line 7))
#7 29.20   Downloading pycares-4.0.0.tar.gz (819 kB)
#7 29.25      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 819.7/819.7 kB 16.8 MB/s  0:00:00
#7 29.39   Installing build dependencies: started
#7 30.10   Installing build dependencies: finished with status 'done'
#7 30.10   Getting requirements to build wheel: started
#7 30.44   Getting requirements to build wheel: finished with status 'done'
#7 30.44   Installing backend dependencies: started
#7 31.41   Installing backend dependencies: finished with status 'done'
#7 31.41   Preparing metadata (pyproject.toml): started
#7 31.74   Preparing metadata (pyproject.toml): finished with status 'done'
#7 31.80 Collecting pyyaml==6.0.1 (from -r requirements.txt (line 8))
#7 31.81   Downloading PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.1 kB)
#7 31.96 Collecting charset-normalizer<4,>=2 (from requests==2.32.3->-r requirements.txt (line 4))
#7 31.98   Downloading charset_normalizer-3.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (37 kB)
#7 32.01 Collecting idna<4,>=2.5 (from requests==2.32.3->-r requirements.txt (line 4))
#7 32.02   Downloading idna-3.11-py3-none-any.whl.metadata (8.4 kB)
#7 32.06 Collecting certifi>=2017.4.17 (from requests==2.32.3->-r requirements.txt (line 4))
#7 32.07   Downloading certifi-2026.2.25-py3-none-any.whl.metadata (2.5 kB)
#7 32.10 Collecting six>=1.7.3 (from pyvmomi==8.0.2.0.1->-r requirements.txt (line 5))
#7 32.11   Downloading six-1.17.0-py2.py3-none-any.whl.metadata (1.7 kB)
#7 32.21 Collecting cffi>=1.5.0 (from pycares==4.0.0->-r requirements.txt (line 7))
#7 32.21   Using cached cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl.metadata (2.6 kB)
#7 32.23 Collecting pycparser (from cffi>=1.5.0->pycares==4.0.0->-r requirements.txt (line 7))
#7 32.23   Using cached pycparser-3.0-py3-none-any.whl.metadata (8.2 kB)
#7 32.25 Downloading urllib3-2.2.2-py3-none-any.whl (121 kB)
#7 32.26 Downloading requests-2.32.3-py3-none-any.whl (64 kB)
#7 32.28 Downloading aiodns-3.0.0-py3-none-any.whl (5.0 kB)
#7 32.30 Downloading PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (757 kB)
#7 32.34    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 757.7/757.7 kB 21.9 MB/s  0:00:00
#7 32.35 Downloading charset_normalizer-3.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (151 kB)
#7 32.37 Downloading idna-3.11-py3-none-any.whl (71 kB)
#7 32.39 Downloading packaging-26.0-py3-none-any.whl (74 kB)
#7 32.40 Downloading wheel-0.46.3-py3-none-any.whl (30 kB)
#7 32.42 Downloading certifi-2026.2.25-py3-none-any.whl (153 kB)
#7 32.44 Using cached cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (215 kB)
#7 32.45 Downloading six-1.17.0-py2.py3-none-any.whl (11 kB)
#7 32.46 Using cached pycparser-3.0-py3-none-any.whl (48 kB)
#7 32.47 Building wheels for collected packages: pyvmomi, pycares
#7 32.47   Building wheel for pyvmomi (pyproject.toml): started
#7 32.91   Building wheel for pyvmomi (pyproject.toml): finished with status 'done'
#7 32.91   Created wheel for pyvmomi: filename=pyvmomi-8.0.2.0.1-py2.py3-none-any.whl size=527790 sha256=fe8fe7a0b8c78fac0b52c65a462c1cbfb556bf5775e747aeafcc2fcc113f750d
#7 32.91   Stored in directory: /root/.cache/pip/wheels/58/00/35/035f172707b539c0edd6e086053a4f177a424c0ab807799d1f
#7 32.91   Building wheel for pycares (pyproject.toml): started
#7 33.21   Building wheel for pycares (pyproject.toml): finished with status 'error'
#7 33.22   error: subprocess-exited-with-error
#7 33.22   
#7 33.22   × Building wheel for pycares (pyproject.toml) did not run successfully.
#7 33.22   │ exit code: 1
#7 33.22   ╰─> [35 lines of output]
#7 33.22       /tmp/pip-build-env-dovj6525/overlay/lib/python3.11/site-packages/setuptools/dist.py:765: SetuptoolsDeprecationWarning: License classifiers are deprecated.
#7 33.22       !!
#7 33.22       
#7 33.22               ********************************************************************************
#7 33.22               Please consider removing the following classifiers in favor of a SPDX license expression:
#7 33.22       
#7 33.22               License :: OSI Approved :: MIT License
#7 33.22       
#7 33.22               See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
#7 33.22               ********************************************************************************
#7 33.22       
#7 33.22       !!
#7 33.22         self._finalize_license_expression()
#7 33.22       running bdist_wheel
#7 33.22       running build
#7 33.22       running build_py
#7 33.22       creating build/lib.linux-x86_64-cpython-311/pycares
#7 33.22       copying src/pycares/_version.py -> build/lib.linux-x86_64-cpython-311/pycares
#7 33.22       copying src/pycares/__init__.py -> build/lib.linux-x86_64-cpython-311/pycares
#7 33.22       copying src/pycares/__main__.py -> build/lib.linux-x86_64-cpython-311/pycares
#7 33.22       copying src/pycares/errno.py -> build/lib.linux-x86_64-cpython-311/pycares
#7 33.22       copying src/pycares/utils.py -> build/lib.linux-x86_64-cpython-311/pycares
#7 33.22       running build_ext
#7 33.22       generating cffi module 'build/temp.linux-x86_64-cpython-311/_cares.c'
#7 33.22       creating build/temp.linux-x86_64-cpython-311
#7 33.22       building '_cares' extension
#7 33.22       creating build/temp.linux-x86_64-cpython-311/build/temp.linux-x86_64-cpython-311
#7 33.22       creating build/temp.linux-x86_64-cpython-311/deps/c-ares/src/lib
#7 33.22       gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DHAVE_CONFIG_H=1 -D_LARGEFILE_SOURCE=1 -D_FILE_OFFSET_BITS=64 -DCARES_STATICLIB=1 -Ideps/build-config/config_linux -Ideps/build-config/include -Ideps/c-ares/include -I/opt/netbox-sync/venv/include -I/usr/local/include/python3.11 -c build/temp.linux-x86_64-cpython-311/_cares.c -o build/temp.linux-x86_64-cpython-311/build/temp.linux-x86_64-cpython-311/_cares.o
#7 33.22       In file included from build/temp.linux-x86_64-cpython-311/_cares.c:57:
#7 33.22       /usr/local/include/python3.11/Python.h:23:12: fatal error: stdlib.h: No such file or directory
#7 33.22          23 | #  include <stdlib.h>
#7 33.22             |            ^~~~~~~~~~
#7 33.22       compilation terminated.
#7 33.22       error: command '/usr/bin/gcc' failed with exit code 1
#7 33.22       [end of output]
#7 33.22   
#7 33.22   note: This error originates from a subprocess, and is likely not a problem with pip.
#7 33.22   ERROR: Failed building wheel for pycares
#7 33.22 Successfully built pyvmomi
#7 33.22 Failed to build pycares
#7 33.22 error: failed-wheel-build-for-install
#7 33.22 
#7 33.22 × Failed to build installable wheels for some pyproject.toml based projects
#7 33.22 ╰─> pycares
#7 ERROR: process "/bin/sh -c apt-get update && apt-get install -y --no-install-recommends git cmake gcc &&     rm -rf /var/lib/apt/lists/* &&     python3 -m venv $VENV &&     $VENV/bin/python3 -m pip install --upgrade pip &&     $VENV/bin/pip install -r requirements.txt &&     $VENV/bin/pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git &&     find $VENV -type d -name \"__pycache__\" -print0 | xargs -0 -n1 rm -rf" did not complete successfully: exit code: 1
------
 > [builder 3/3] RUN apt-get update && apt-get install -y --no-install-recommends git cmake gcc &&     rm -rf /var/lib/apt/lists/* &&     python3 -m venv /opt/netbox-sync/venv &&     /opt/netbox-sync/venv/bin/python3 -m pip install --upgrade pip &&     /opt/netbox-sync/venv/bin/pip install -r requirements.txt &&     /opt/netbox-sync/venv/bin/pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git &&     find /opt/netbox-sync/venv -type d -name "__pycache__" -print0 | xargs -0 -n1 rm -rf:
33.22       [end of output]
33.22   
33.22   note: This error originates from a subprocess, and is likely not a problem with pip.
33.22   ERROR: Failed building wheel for pycares
33.22 Successfully built pyvmomi
33.22 Failed to build pycares
33.22 error: failed-wheel-build-for-install
33.22 
33.22 × Failed to build installable wheels for some pyproject.toml based projects
33.22 ╰─> pycares
------
Dockerfile:8
--------------------
   7 |     # Install dependencies
   8 | >>> RUN apt-get update && apt-get install -y --no-install-recommends git cmake gcc && \
   9 | >>>     rm -rf /var/lib/apt/lists/* && \
  10 | >>>     python3 -m venv $VENV && \
  11 | >>>     $VENV/bin/python3 -m pip install --upgrade pip && \
  12 | >>>     $VENV/bin/pip install -r requirements.txt && \
  13 | >>>     $VENV/bin/pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git && \
  14 | >>>     find $VENV -type d -name "__pycache__" -print0 | xargs -0 -n1 rm -rf
  15 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update && apt-get install -y --no-install-recommends git cmake gcc &&     rm -rf /var/lib/apt/lists/* &&     python3 -m venv $VENV &&     $VENV/bin/python3 -m pip install --upgrade pip &&     $VENV/bin/pip install -r requirements.txt &&     $VENV/bin/pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git &&     find $VENV -type d -name \"__pycache__\" -print0 | xargs -0 -n1 rm -rf" did not complete successfully: exit code: 1

```


the addition of gcc and libc-dev to the image fixes the build