### PR TITLE
feat: add support for NetBox 4.5+ v2 API tokens (Bearer auth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ In order to updated data in NetBox you need a NetBox API token.
   * auth
   * secrets
   * users
+* Both v1 (legacy) and v2 tokens (NetBox 4.5+, `nbt_` prefix) are supported.
+  The correct authorization header (`Token` or `Bearer`) is detected automatically.
 
 A short description can be found [here](https://docs.netbox.dev/en/stable/integrations/rest-api/#authentication)
 

--- a/module/netbox/config.py
+++ b/module/netbox/config.py
@@ -26,7 +26,8 @@ class NetBoxConfig(ConfigBase):
             ConfigOption("api_token",
                          str,
                          description="""Requires an NetBox API token with full permissions on all objects except
-                         'auth', 'secrets' and 'users'
+                         'auth', 'secrets' and 'users'.
+                         Both v1 (legacy) and v2 (NetBox 4.5+, nbt_ prefix) tokens are supported.
                          """,
                          config_example="XYZ",
                          mandatory=True,

--- a/module/netbox/connection.py
+++ b/module/netbox/connection.py
@@ -152,8 +152,10 @@ class NetBoxHandler:
         requests.Session: session handler of new NetBox session
         """
 
+        token = self.settings.api_token
+        keyword = "Bearer" if token.startswith("nbt_") else "Token"
         header = {
-            "Authorization": f"Token {self.settings.api_token}",
+            "Authorization": f"{keyword} {token}",
             "User-Agent": f"netbox-sync/{__version__}",
             "Content-Type": "application/json"
         }

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -45,6 +45,7 @@
 
 ; Requires an NetBox API token with full permissions on all objects except 'auth',
 ; 'secrets' and 'users'
+; Both v1 (legacy) and v2 (NetBox 4.5+, nbt_ prefix) tokens are supported.
 api_token = XYZ
 
 ; Requires a hostname or IP which points to your NetBox instance

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -44,8 +44,8 @@
 [netbox]
 
 ; Requires an NetBox API token with full permissions on all objects except 'auth',
-; 'secrets' and 'users'
-; Both v1 (legacy) and v2 (NetBox 4.5+, nbt_ prefix) tokens are supported.
+; 'secrets' and 'users'. Both v1 (legacy) and v2 (NetBox 4.5+, nbt_ prefix) tokens are
+; supported.
 api_token = XYZ
 
 ; Requires a hostname or IP which points to your NetBox instance


### PR DESCRIPTION
## Summary

NetBox 4.5 introduced [v2 API tokens](https://github.com/netbox-community/netbox/issues/14702) with the format `nbt_<key>.<plaintext>`, which require the `Bearer` authorization keyword instead of the legacy `Token` keyword.

Currently, `netbox-sync` hardcodes `Token` in the `Authorization` header (`module/netbox/connection.py`), making it incompatible with v2 tokens on NetBox 4.5+.

This PR auto-detects the token version by checking the `nbt_` prefix and uses the appropriate authorization keyword:

- `nbt_*` tokens → `Authorization: Bearer <token>`
- Legacy tokens → `Authorization: Token <token>` (fully backward compatible)

This matches how NetBox itself distinguishes token versions in [`netbox/api/authentication.py`](https://github.com/netbox-community/netbox/blob/main/netbox/netbox/api/authentication.py) (`V1_KEYWORD = 'Token'`, `V2_KEYWORD = 'Bearer'`).

## Changes

- **`module/netbox/connection.py`**: Detect token version by `nbt_` prefix, use `Bearer` or `Token` accordingly
- **`README.md`**: Document v2 token support
- **`settings-example.ini`**: Add comment about v2 token format

## Test plan

- [ ] Test with NetBox 4.5+ using a v2 token (`nbt_` prefix) — sync completes successfully
- [ ] Test with NetBox using a legacy v1 token — backward compatibility confirmed
- [ ] Test with NetBox < 4.5 using a v1 token — no behavior change