### PR TITLE
CI: fix docker hub push

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,19 +25,19 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Lower case docker image name
         id: docker_image
-        uses: ASzc/change-string-case-action@v6
+        uses: ASzc/change-string-case-action@v8
         with:
           string: ${{ github.repository }}
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: Docker meta GitHub Container Registry
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ steps.docker_image.outputs.lowercase }}
           tags: |
@@ -53,7 +53,7 @@ jobs:
             type=ref,event=branch
 
       - name: Build and push with tags - ${{ steps.meta.outputs.tags }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -62,14 +62,14 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Docker hub meta
         id: meta_dhub
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: docker.io/bbricardo/${{ steps.docker_image.outputs.lowercase }}
           tags: |
@@ -77,7 +77,7 @@ jobs:
             type=ref,event=branch
 
       - name: Build and push with tags - ${{ steps.meta_dhub.outputs.tags }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -43,16 +43,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker meta GitHub Container Registry
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ steps.docker_image.outputs.lowercase }}
+          images: |
+            ghcr.io/${{ steps.docker_image.outputs.lowercase }}
+            docker.io/${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}
           tags: |
             type=semver,pattern={{version}}
             type=ref,event=branch
 
-      - name: Build and push with tags - ${{ steps.meta.outputs.tags }}
+      - name: Build and push
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -60,27 +68,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-
-      - name: Docker hub meta
-        id: meta_dhub
-        uses: docker/metadata-action@v6
-        with:
-          images: docker.io/bbricardo/${{ steps.docker_image.outputs.lowercase }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=ref,event=branch
-
-      - name: Build and push with tags - ${{ steps.meta_dhub.outputs.tags }}
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta_dhub.outputs.tags }}
-          labels: ${{ steps.meta_dhub.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Refactor docker-image workflow to build and push to both GHCR and Docker Hub in a single step instead of building twice.

Also fixes the Docker Hub image name that was producing an invalid 3-level path.

Closes #479 