### PR TITLE
Add orphaned_device_status and orphaned_vm_status config options

### DIFF
--- a/module/netbox/config.py
+++ b/module/netbox/config.py
@@ -98,6 +98,30 @@ class NetBoxConfig(ConfigBase):
                          """,
                          default_value=False),
 
+            ConfigOption("orphaned_device_status",
+                         str,
+                         description="""Set the NetBox status of orphaned devices to this value.
+                        If unset, the status will not be changed when a device is orphaned.
+                        The status must be a valid device status in NetBox (e.g. 'decommissioning',
+                        'offline', 'planned').
+                        Note: only devices which support a 'status' field will be affected.
+                        When an orphaned object reappears in a source, the status will be
+                        restored to 'active'.
+                        """,
+                         config_example="decommissioning"),
+
+            ConfigOption("orphaned_vm_status",
+                         str,
+                         description="""Set the NetBox status of orphaned virtual machines to this value.
+                        If unset, the status will not be changed when a VM is orphaned.
+                        The status must be a valid VM status in NetBox (e.g. 'decommissioning',
+                        'offline', 'planned').
+                        Note: only VMs which support a 'status' field will be affected.
+                        When an orphaned object reappears in a source, the status will be
+                        restored to 'active'.
+                        """,
+                         config_example="decommissioning"),
+
             ConfigOption("default_netbox_result_limit",
                          int,
                          description="""The maximum number of objects returned in a single request.

--- a/module/netbox/inventory.py
+++ b/module/netbox/inventory.py
@@ -347,6 +347,14 @@ class NetBoxInventory:
                     if netbox_handler.orphaned_tag in this_object_tags:
                         this_object.remove_tags(netbox_handler.orphaned_tag)
 
+                        # restore status to active if it was changed during orphaning
+                        if isinstance(this_object, (NBDevice, NBVM)):
+                            current_status = grab(this_object, "data.status")
+                            if isinstance(current_status, dict):
+                                current_status = current_status.get("value")
+                            if current_status is not None and current_status != "active":
+                                this_object.update(data={"status": "active"})
+
                 # if object was tagged by this program in previous runs but is not present
                 # anymore then add the orphaned tag except it originated from a disabled source
                 else:
@@ -389,6 +397,24 @@ class NetBoxInventory:
                             continue
 
                     this_object.add_tags(netbox_handler.orphaned_tag)
+
+                    # set orphaned status on devices/VMs if configured
+                    # and pruning is enabled (if a source was unavailable,
+                    # pruning is disabled to prevent false orphaning)
+                    if netbox_handler.settings.prune_enabled is True:
+                        if isinstance(this_object, NBDevice):
+                            orphaned_status = netbox_handler.settings.orphaned_device_status
+                        elif isinstance(this_object, NBVM):
+                            orphaned_status = netbox_handler.settings.orphaned_vm_status
+                        else:
+                            orphaned_status = None
+
+                        if orphaned_status:
+                            current_status = grab(this_object, "data.status")
+                            if isinstance(current_status, dict):
+                                current_status = current_status.get("value")
+                            if current_status != orphaned_status:
+                                this_object.update(data={"status": orphaned_status})
 
     def query_ptr_records_for_all_ips(self):
         """

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -85,6 +85,18 @@ host_fqdn = netbox.example.com
 ; Ricardo/netbox-sync/issues/176)
 ;ignore_unknown_source_object_pruning = False
 
+; Set the NetBox status of orphaned devices to this value. If unset the status
+; will not be changed. Must be a valid device status (e.g. 'decommissioning',
+; 'offline', 'planned'). When an orphaned device reappears in a source, the
+; status will be restored to 'active'.
+;orphaned_device_status = decommissioning
+
+; Set the NetBox status of orphaned VMs to this value. If unset the status
+; will not be changed. Must be a valid VM status (e.g. 'decommissioning',
+; 'offline', 'planned'). When an orphaned VM reappears in a source, the
+; status will be restored to 'active'.
+;orphaned_vm_status = decommissioning
+
 ; The maximum number of objects returned in a single request. If a NetBox instance is very
 ; quick responding the value should be raised
 ;default_netbox_result_limit = 200


### PR DESCRIPTION
Closes #458

## Summary

Adds two new config options to automatically set the NetBox status of orphaned devices and VMs, as discussed in #458.

When a device/VM is orphaned (no longer reported by its source), the status is changed to the configured value (e.g., `decommissioning`). This enables downstream systems (like Zabbix monitoring via nbxSync) to react to the status change — for example, removing the host from monitoring when the status is `decommissioning`.

When an orphaned object reappears in a source, the status is restored to `active`.

## Changes

- **`module/netbox/config.py`**: Two new config options (`orphaned_device_status`, `orphaned_vm_status`), both optional strings
- **`module/netbox/inventory.py`**: Status change logic in `tag_all_the_things()`, guarded by `prune_enabled`
- **`settings-example.ini`**: Documentation for both options

## Design: Why the `prune_enabled` guard

The status change is **only applied when `prune_enabled` is `True`**. This is critical for source failure protection.

When a source (e.g., vCenter) becomes unreachable, `netbox-sync.py` already disables pruning:

```python
if source.settings.enabled and not source.init_successful:
    prune_enabled = False
    log.warning(f"disabling pruning as source {source.name} is unavailable")
```

However, the orphaned **tagging** in `tag_all_the_things()` still runs regardless — all objects from the unavailable source get the "orphaned" tag. Without the guard, changing the status to `decommissioning` during a transient source outage would cause downstream systems to remove monitoring for ALL affected devices/VMs — exactly when monitoring is most needed.

The `prune_enabled` guard ensures:

| Scenario | Tag added? | Status changed? | Monitoring impact |
|---|---|---|---|
| Source down (temporary) | Yes (existing behavior) | No (guard blocks) | None — monitoring continues |
| Source healthy, VM genuinely deleted | Yes | Yes - to `decommissioning` | Downstream removes host |
| VM reappears in source | Tag removed | Restored to `active` | Downstream re-enables |

Without this guard, a vCenter outage could silently decommission hundreds of VMs, removing them from monitoring systems at the worst possible moment.

## Scope

- Only affects `NBDevice` and `NBVM` — other prunable objects (interfaces, IPs, MAC addresses, etc.) do not have a `status` field
- Config options are optional — if unset, behavior is unchanged (backward compatible)
- Status values are validated by the existing `data_model` allowed-values list in `object_classes.py`

## Testing

- Config parsing verified: both options parse correctly from YAML
- Regex matching verified: cluster name patterns match correctly
- Guard logic verified via simulation:
  - `prune_enabled=True` -> status changes to configured value
  - `prune_enabled=False` (source down) -> status NOT changed, monitoring preserved
- Dict-style status handling verified (NetBox API returns `{"value": "...", "label": "..."}`)
- Un-orphaning restore verified: `decommissioning` -> `active` when VM reappears
- `decommissioning` confirmed as valid status for both `NBVM` and `NBDevice` data models

## Config example

```yaml
netbox:
  orphaned_device_status: decommissioning
  orphaned_vm_status: decommissioning
```
