### PR TITLE
vmware: add tag_name_include_category option

### DIFF
--- a/module/sources/vmware/config.py
+++ b/module/sources/vmware/config.py
@@ -284,6 +284,17 @@ class VMWareConfig(ConfigBase):
                                 ConfigOption("host_tag_source", str),
                                 ConfigOption("vm_tag_source", str)
                               ]),
+            ConfigOption("tag_name_include_category",
+                         bool,
+                         description="""\
+                         If enabled, vCenter tag names synced to NetBox will include the vCenter category as a
+                         prefix in the format 'CategoryName:TagName'. Useful if TagName and CategoryName is used 
+                         as key/value pairs in vCenter.
+                         When changed, existing synced tags are replaced on
+                         the next run. Note: vm_exclude_by_tag_filter entries must use 'CategoryName:TagName'
+                         format when this option is enabled.
+                         """,
+                         default_value=False),
             ConfigOption("sync_custom_attributes",
                          bool,
                          description="""sync custom attributes defined for hosts and VMs

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -681,21 +681,32 @@ class VMWareHandler(SourceBase):
 
                 # noinspection PyBroadException
                 try:
-                    tag_name = self.tag_session.tagging.Tag.get(tag_id).name
-                    tag_description = self.tag_session.tagging.Tag.get(tag_id).description
+                    tag = self.tag_session.tagging.Tag.get(tag_id)  # store the object
+                    tag_name = tag.name
+                    tag_description = tag.description
                 except Exception as e:
                     log.error(f"Unable to retrieve vCenter tag '{tag_id}' for '{obj.name}': {e}")
-                    continue
+                    continue  # skip tag entirely if basic fetch fails
+
+                try:
+                    category_name = self.tag_session.tagging.Category.get(tag.category_id).name
+                except Exception:
+                    category_name = None  # gracefully degrade — tag still gets added
 
                 if tag_name is not None:
-
                     if tag_description is not None and len(f"{tag_description}") > 0:
                         tag_description = f"{primary_tag_name}: {tag_description}"
                     else:
                         tag_description = primary_tag_name
 
+                    if category_name and not self.settings.tag_name_include_category:
+                        tag_description = f"{category_name}: {tag_description}" if tag_description else category_name
+
+                    effective_tag_name = f"{category_name}:{tag_name}" \
+                        if category_name and self.settings.tag_name_include_category else tag_name
+
                     tag_list.append(self.inventory.add_update_object(NBTag, data={
-                        "name": tag_name,
+                        "name": effective_tag_name,
                         "description": tag_description
                     }))
 
@@ -2230,8 +2241,9 @@ class VMWareHandler(SourceBase):
         vcenter_tags = self.collect_object_tags(obj)
 
         # check if VM tag excludes VM from being synced to NetBox
+        vcenter_tag_names = [NetBoxObject.extract_tag_name(t) for t in vcenter_tags]
         for sync_exclude_tag in self.settings.vm_exclude_by_tag_filter or list():
-            if sync_exclude_tag in vcenter_tags:
+            if sync_exclude_tag in vcenter_tag_names:
                 log.debug(f"Virtual machine vCenter tag '{sync_exclude_tag}' in matches 'vm_exclude_by_tag_filter'. "
                           f"Skipping")
                 return

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -308,6 +308,14 @@ password = super-secret
 ;host_tag_source =
 ;vm_tag_source =
 
+; If enabled, vCenter tag names synced to NetBox will include the vCenter category as a
+; prefix in the format 'CategoryName:TagName'. Useful if TagName and CategoryName is used 
+; as key/value pairs in vCenter.
+; When changed, existing synced tags are replaced on
+; the next run. Note: vm_exclude_by_tag_filter entries must use 'CategoryName:TagName'
+; format when this option is enabled.
+;tag_name_include_category = False
+
 ; sync custom attributes defined for hosts and VMs in vCenter to NetBox as custom fields
 ;sync_custom_attributes = False
 


### PR DESCRIPTION
vCenter tags have both a name and a category, but only the tag name was previously synced to NetBox. This loses context and makes it hard to distinguish tags that share a name across different categories.

**Changes**

- Add new config option tag_name_include_category (bool, default False) in the VMware source config. When enabled, tags are synced to NetBox as CategoryName:TagName instead of just TagName.

- The option is backward compatible — existing behaviour is preserved when False.

- On first run after enabling, old bare-name tags are cleanly removed from objects and replaced with the prefixed format. Old orphaned tags in NetBox must be deleted manually as before.

**Config example**
`tag_name_include_category = True`

- With a vCenter tag named HR in category Department, NetBox will store the tag as Department:HR.

**Note**: 
if vm_exclude_by_tag_filter is in use and tag_name_include_category is enabled, filter entries must be updated to the CategoryName:TagName format.