### PR TITLE
fixes primary IP matching for resolved IP address objects

### DIFF
--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -709,7 +709,10 @@ class VMWareHandler(SourceBase):
 
             ip = None
             if device_primary_ip is not None and ip_needle is not None:
-                if isinstance(device_primary_ip, dict):
+                if isinstance(device_primary_ip, NBIPAddress):
+                    ip = grab(device_primary_ip, "data.address")
+
+                elif isinstance(device_primary_ip, dict):
                     ip = grab(device_primary_ip, "address")
 
                 elif isinstance(device_primary_ip, int):


### PR DESCRIPTION
Resolves #521

## Problem

`get_object_based_on_primary_ip()` in the vmware source can never match an existing device or VM. After the inventory resolves relations (`NetBoxObject.resolve_relations()`), `data.primary_ip4` / `data.primary_ip6` hold resolved `NBIPAddress` **objects**, but the inner helper `_matches_device_primary_ip()` only handles `dict` and `int` values — an `NBIPAddress` instance falls through and the function silently returns `False` for every device.

Effect: devices/VMs which can only be identified by their primary IP — i.e. no name+cluster match (VM moved to a different cluster), no MAC addresses stored in NetBox, and no serial — are **duplicated** instead of updated. Easy to reproduce on any pre-populated NetBox where VM records were created by another tool without MACs/serials: run netbox-sync, watch it log `No match found. Trying to find virtual machine based on primary IP addresses` and then create a second VM with the same name.

(Verified on v1.8.1 with DEBUG2 logs: across a full run of two vCenter sources, 10 VMs reached the primary-IP stage and 0 matched, including VMs whose NetBox primary IP was exactly the source-derived primary IP.)

## Fix

Handle the resolved-object case in `_matches_device_primary_ip()`:

```python
if isinstance(device_primary_ip, NBIPAddress):
    ip = grab(device_primary_ip, "data.address")
```

The `dict` and `int` branches are kept for values which have not been resolved (yet).

One-line behavior change, no config impact.


(cherry picked from commit e8702f4a9f177bcdc86987df5a885b119ee1bd81)