### PR TITLE
fixes object/multi-object custom field handling for NetBox 4.x

### DIFF
--- a/module/netbox/object_classes.py
+++ b/module/netbox/object_classes.py
@@ -685,27 +685,47 @@ class NetBoxObject:
 
                 # Fix for object/multi-object custom fields
                 # When patching, we only need the IDs, not the full object representation
-                new_value_copy = new_value.copy()
-                for field_name, field_value in new_value_copy.items():
-                    # Check for custom field type
-                    custom_field = self.inventory.get_by_data(NBCustomField, data={"name": field_name})
-                    if custom_field is not None:
+                # returned by the NetBox API. The values of the current AND the new data
+                # need to be reduced. Reducing only the new values would miss unchanged
+                # object custom fields which get merged into the update from the current
+                # data, and comparing reduced to unreduced values would report a change
+                # on every run.
+                def reduce_object_custom_fields_to_ids(custom_field_data: dict) -> dict:
+
+                    reduced_data = dict(custom_field_data)
+                    for field_name, field_value in custom_field_data.items():
+                        # Check for custom field type
+                        custom_field = self.inventory.get_by_data(NBCustomField, data={"name": field_name})
+                        if custom_field is None:
+                            continue
+
                         field_type = grab(custom_field, "data.type")
 
+                        # custom fields read from the NetBox API report the type as
+                        # a dict like {"value": "multiobject", "label": "Multiple objects"}
+                        if isinstance(field_type, dict):
+                            field_type = field_type.get("value")
+
                         # Handle object type custom fields - need only ID
-                        if field_type == "object" and isinstance(field_value, dict) and field_value.get('id') is not None:
-                            new_value[field_name] = field_value.get('id')
+                        if field_type == "object" and isinstance(field_value, dict) and \
+                                field_value.get('id') is not None:
+                            reduced_data[field_name] = field_value.get('id')
 
                         # Handle multi-object type custom fields - need list of IDs
-                        elif field_type == "multi-object" and isinstance(field_value, list):
+                        # NetBox reports the type of these fields as 'multiobject'
+                        elif field_type in ("multiobject", "multi-object") and isinstance(field_value, list):
                             ids = []
                             for item in field_value:
                                 if isinstance(item, dict) and item.get('id') is not None:
                                     ids.append(item.get('id'))
                             if ids:
-                                new_value[field_name] = ids
+                                reduced_data[field_name] = ids
 
-                new_value = {**current_value, **new_value}
+                    return reduced_data
+
+                current_value = reduce_object_custom_fields_to_ids(current_value)
+                current_value_str = str(current_value)
+                new_value = {**current_value, **reduce_object_custom_fields_to_ids(new_value)}
                 new_value_str = str(new_value)
             elif isinstance(new_value, (NetBoxObject, NBObjectList)):
                 new_value_str = str(new_value.get_display_name())
@@ -1310,7 +1330,8 @@ class NBCustomField(NetBoxObject):
             "object_types": list,
             # field name (object_types) for NetBox < 4.0.0
             "content_types": list,
-            "type": ["text", "longtext", "integer", "boolean", "date", "url", "json", "select", "multiselect", "object", "multi-object"],
+            "type": ["text", "longtext", "integer", "boolean", "date", "url", "json", "select", "multiselect", "object",
+                     "multiobject", "multi-object"],
             "name": 50,
             "label": 50,
             "description": 200,


### PR DESCRIPTION
Resolves #522

## Problem

The fix from #452 (`5c8e54cd`, "handle object and multi-object custom fields correctly") never triggers when custom fields are loaded from the NetBox API, for two reasons:

1. The API reports the field type as a dict — `{"value": "multiobject", "label": "Multiple objects"}` — so `grab(custom_field, "data.type") == "object"` (a plain-string comparison) is always False.
2. NetBox's actual type value for multi-object fields is `multiobject` (`CustomFieldTypeChoices.TYPE_MULTIOBJECT`), not `multi-object`.
3. Only the new (incoming) custom field values were reduced to IDs. Object custom fields which are *not* part of the update — e.g. a custom field maintained by another tool — get merged into the update payload from the current NetBox data (`new_value = {**current_value, **new_value}`) and were still sent as their full serialized representation.

Effect: any device/VM carrying a populated object or multi-object custom field is PATCHed with the full serialized object representation, which NetBox rejects with `{'custom_fields': ["Cannot resolve keyword 'display' into field. ..."]}` — and the object then receives **no updates at all** on any field, every run. (Verified against NetBox 4.5.10 with a multi-object tenant custom field.)

## Fix

* Normalize the dict form to its `value` before comparing.
* Accept `multiobject` (and keep `multi-object` for compatibility).
* Reduce the current **and** the new custom field values to IDs before merging/comparing — this covers fields merged in from current data, and keeps both sides comparable so unchanged object custom fields no longer report a change on every run.
* Add `multiobject` to the valid type list in `NBCustomField.data_model`.