### PR TITLE
Feature: Add preserve_primary_ips option

### DIFF
--- a/module/sources/common/source_base.py
+++ b/module/sources/common/source_base.py
@@ -46,6 +46,51 @@ class SourceBase:
     def finish(self):
         pass
 
+    def ip_is_primary_ip_of_object(self, ip_object, device_vm_object) -> bool:
+        """
+        Check if a NBIPAddress object is currently set as primary IPv4 or IPv6
+        address of a NBDevice or NBVM object.
+
+        Parameters
+        ----------
+        ip_object: NBIPAddress
+            IP address object to check
+        device_vm_object: NBDevice | NBVM
+            device or VM object to compare the primary IPs of
+
+        Returns
+        -------
+        bool: True if 'ip_object' is set as 'primary_ip4' or 'primary_ip6'
+        """
+
+        if not isinstance(ip_object, NBIPAddress) or not isinstance(device_vm_object, (NBDevice, NBVM)):
+            return False
+
+        ip_address = grab(ip_object, "data.address")
+
+        for primary_ip_key in ["primary_ip4", "primary_ip6"]:
+
+            primary_ip = grab(device_vm_object, f"data.{primary_ip_key}")
+
+            if primary_ip is None:
+                continue
+
+            if primary_ip is ip_object:
+                return True
+
+            primary_ip_address = None
+            if isinstance(primary_ip, NBIPAddress):
+                primary_ip_address = grab(primary_ip, "data.address")
+            elif isinstance(primary_ip, dict):
+                primary_ip_address = primary_ip.get("address")
+            elif isinstance(primary_ip, int):
+                primary_ip_address = grab(self.inventory.get_by_id(NBIPAddress, nb_id=primary_ip), "data.address")
+
+            if primary_ip_address is not None and primary_ip_address == ip_address:
+                return True
+
+        return False
+
     def map_object_interfaces_to_current_interfaces(self, device_vm_object, interface_data_dict=None,
                                                     append_unmatched_interfaces=False):
         """
@@ -610,6 +655,14 @@ class SourceBase:
                 continue
 
             if current_ip not in ip_address_objects:
+
+                if bool(self.settings.preserve_primary_ips) is True and \
+                        self.ip_is_primary_ip_of_object(current_ip, device_object):
+                    log.debug(f"{current_ip.name} '{current_ip.get_display_name()}' is the primary IP of "
+                              f"'{device_object.get_display_name()}' and 'preserve_primary_ips' is enabled. "
+                              f"NOT removing it from this interface")
+                    continue
+
                 log.info(f"{current_ip.name} is no longer assigned to {interface_object.get_display_name()} and "
                          f"therefore removed from this interface")
                 current_ip.remove_interface_association()

--- a/module/sources/vmware/config.py
+++ b/module/sources/vmware/config.py
@@ -259,6 +259,15 @@ class VMWareConfig(ConfigBase):
                                        as "when-undefined"
                          """,
                          default_value="when-undefined"),
+            ConfigOption("preserve_primary_ips",
+                         bool,
+                         description="""defines if primary IP addresses of devices and VMs are protected from
+                         removal. If enabled, an IP address which is set as primary IPv4/IPv6 of a device or
+                         VM in NetBox will never be removed from its interface by this source, even if the
+                         source does not report this IP address (anymore). This prevents the primary IP from
+                         being unset when i.e. an outdated guest agent does not report all IP addresses.
+                         """,
+                         default_value=False),
             ConfigOption("skip_vm_comments",
                          bool,
                          description="Do not sync notes from a VM in vCenter to the comments field on a VM in netbox",

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -285,6 +285,13 @@ password = super-secret
 ;               as "when-undefined"
 ;set_primary_ip = when-undefined
 
+; defines if primary IP addresses of devices and VMs are protected from removal. If
+; enabled, an IP address which is set as primary IPv4/IPv6 of a device or VM in NetBox
+; will never be removed from its interface by this source, even if the source does not
+; report this IP address (anymore). This prevents the primary IP from being unset when
+; i.e. an outdated guest agent does not report all IP addresses.
+;preserve_primary_ips = False
+
 ; Do not sync notes from a VM in vCenter to the comments field on a VM in netbox
 ;skip_vm_comments = False
 


### PR DESCRIPTION
## Problem

When a guest agent does not report all IP addresses of a VM (common with very old guest OSes — e.g. VMware Tools on CentOS 4/5-era guests reporting no IPv4 addresses at all), netbox-sync removes the "missing" IP address from the interface:

```
INFO: IP address is no longer assigned to eth0 (vm.example.com) and therefore removed from this interface
INFO: Setting attribute 'primary_ip4' for 'vm.example.com' to None
```

If that address is the primary IP of the device/VM, the primary IP gets unset as a side effect — on every run. Data that was correct in NetBox (often set manually or by another tool) is destroyed because the source under-reports.

## Solution

New option `preserve_primary_ips` (bool, default `false` — behavior unchanged when unset): an IP address which is currently set as primary IPv4/IPv6 of a device or VM will never be removed from its interface by the source, and the primary IP therefore never gets unset.

Enforced in `add_update_interface()` next to the existing anycast protection; a new `SourceBase.ip_is_primary_ip_of_object()` helper handles the resolved-object/dict/int forms of `data.primary_ip4/6`.

`settings-example.ini` regenerated with `-g`.

Tested against NetBox 4.5.10 with two vCenter sources.