### PR TITLE
Feature: single IPv4 address as primary IPv4 fallback

### DIFF
--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -2693,6 +2693,25 @@ class VMWareHandler(SourceBase):
 
                 nic_data[int_full_name] = vm_nic_data
 
+        # if VM has only one IPv4 on all interfaces, use it as primary IPv4 address
+        if vm_primary_ip4 is None:
+            potential_primary_ipv4_list = list()
+
+            for ip in [y for xs in nic_ips.values() for y in xs]:
+                # noinspection PyBroadException
+                try:
+                    ip_address_object = ip_interface(ip)
+                except Exception:
+                    continue
+
+                if ip_address_object.version == 4:
+                    potential_primary_ipv4_list.append(ip_address_object)
+
+            if len(potential_primary_ipv4_list) == 1:
+                log.debug(f"Found one IPv4 '{potential_primary_ipv4_list[0]}' address on all interfaces of "
+                          f"VM '{name}', using it as primary IPv4.")
+                vm_primary_ip4 = potential_primary_ipv4_list[0]
+
         # if VM has only one IPv6 on all interfaces, use it as primary IPv6 address
         if vm_primary_ip6 is None or True:
             all_ips = [y for xs in nic_ips.values() for y in xs]


### PR DESCRIPTION
## Problem

The primary IPv4 of a VM is only detected when the guest's default gateway is reported by VMware Tools and an interface IP shares that gateway's subnet. Appliance-style guests frequently report their IP addresses but no routing table — such VMs never get a primary IPv4, even when they only have a single IPv4 address and the choice is unambiguous.

The IPv6 code path already handles exactly this case: "if VM has only one IPv6 on all interfaces, use it as primary IPv6 address."

## Solution

Mirror the existing IPv6 fallback for IPv4: if no primary IPv4 was determined via the default gateway and the VM has exactly one IPv4 address across all interfaces, use that address as the primary IPv4 candidate. Whether it is written to NetBox still follows the `set_primary_ip` option (`always` / `when-undefined` / `never`) exactly as before.

Tested against NetBox 4.5.10 with two vCenter sources.