### PR TITLE
Feature: add {vm,host}_interface_exclude_filter  options

### DIFF
--- a/module/sources/common/source_base.py
+++ b/module/sources/common/source_base.py
@@ -68,6 +68,10 @@ class SourceBase:
                 ens1 > vNIC 3
                 ...  > ...
 
+            Current interfaces whose name matches the source setting 'vm_interface_exclude_filter'
+            (or 'host_interface_exclude_filter' for devices) are excluded from all matching
+            attempts and will therefore never be altered.
+
         Parameters
         ----------
         device_vm_object: (NBDevice, NBVM)
@@ -96,6 +100,11 @@ class SourceBase:
 
         log.debug2("Trying to match current object interfaces in NetBox with discovered interfaces")
 
+        if isinstance(device_vm_object, NBVM):
+            interface_exclude_filter = self.settings.vm_interface_exclude_filter
+        else:
+            interface_exclude_filter = self.settings.host_interface_exclude_filter
+
         current_object_interfaces = {
             "virtual": dict(),
             "physical": dict()
@@ -109,6 +118,12 @@ class SourceBase:
         for interface in self.inventory.get_all_interfaces(device_vm_object):
             int_mac = grab(interface, "data.mac_address")
             int_name = grab(interface, "data.name")
+
+            if interface_exclude_filter is not None and int_name is not None and \
+                    interface_exclude_filter.match(int_name):
+                log.debug2(f"Current interface '{int_name}' matches interface_exclude_filter. "
+                           f"Excluding it from all interface matching attempts")
+                continue
             int_type = "virtual"
             if "virtual" not in str(grab(interface, "data.type", fallback="virtual")):
                 int_type = "physical"

--- a/module/sources/vmware/config.py
+++ b/module/sources/vmware/config.py
@@ -426,6 +426,27 @@ class VMWareConfig(ConfigBase):
                          """,
                          config_example="AA:BB:CC:11:22:33, 66:77:88:AA:BB:CC"
                          ),
+            ConfigOption("vm_interface_exclude_filter",
+                         str,
+                         description="""defines a regex expression to exclude VM interfaces from sync by name.
+                         VM interfaces in NetBox whose name matches this filter are completely ignored by this
+                         source: they are excluded from interface matching and will never be updated or altered.
+                         Discovered VM interfaces with a matching name will be excluded from sync as well.
+                         Useful to protect interfaces which are managed by other tools inside the guest
+                         (i.e. 'tailscale0' or 'docker0') from being overwritten with data of a different
+                         interface. The filter is treated as a regex expression which is only anchored at the
+                         beginning of the name ('$' can be used to anchor the end) and is case sensitive.
+                         If more then one expression should match, a '|' needs to be used
+                         """,
+                         config_example="(tailscale|docker)\\d+$"
+                         ),
+            ConfigOption("host_interface_exclude_filter",
+                         str,
+                         description="""defines a regex expression to exclude host interfaces from sync by name.
+                         Same behavior as 'vm_interface_exclude_filter' but applies to host (device) interfaces.
+                         """,
+                         config_example="(?i)^ipmi"
+                         ),
             ConfigOption("custom_attribute_exclude",
                          str,
                          description="""defines a comma separated list of custom attribute which should be excluded

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -1246,8 +1246,20 @@ class VMWareHandler(SourceBase):
         # compile all nic data into one dictionary
         if object_type == NBVM:
             nic_data = vnic_data
+            interface_exclude_filter = self.settings.vm_interface_exclude_filter
         else:
             nic_data = {**pnic_data, **vnic_data}
+            interface_exclude_filter = self.settings.host_interface_exclude_filter
+
+        # exclude discovered interfaces which match the exclude filter
+        if interface_exclude_filter is not None:
+            for int_name in list(nic_data.keys()):
+                if interface_exclude_filter.match(int_name):
+                    log.debug(f"Discovered interface '{int_name}' matches interface_exclude_filter. "
+                              f"Excluding it from sync")
+                    del nic_data[int_name]
+                    if nic_ips is not None:
+                        nic_ips.pop(int_name, None)
 
         # map interfaces of existing object with discovered interfaces
         nic_object_dict = self.map_object_interfaces_to_current_interfaces(device_vm_object, nic_data)

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -413,6 +413,21 @@ password = super-secret
 ; host NIC with a matching MAC address will be excluded from sync.
 ;host_nic_exclude_by_mac_list = AA:BB:CC:11:22:33, 66:77:88:AA:BB:CC
 
+; defines a regex expression to exclude VM interfaces from sync by name. VM interfaces in
+; NetBox whose name matches this filter are completely ignored by this source: they are
+; excluded from interface matching and will never be updated or altered. Discovered VM
+; interfaces with a matching name will be excluded from sync as well. Useful to protect
+; interfaces which are managed by other tools inside the guest (i.e. 'tailscale0' or
+; 'docker0') from being overwritten with data of a different interface. The filter is
+; treated as a regex expression which is only anchored at the beginning of the name ('$'
+; can be used to anchor the end) and is case sensitive. If more then one expression should
+; match, a '|' needs to be used
+;vm_interface_exclude_filter = (tailscale|docker)\d+$
+
+; defines a regex expression to exclude host interfaces from sync by name. Same behavior
+; as 'vm_interface_exclude_filter' but applies to host (device) interfaces.
+;host_interface_exclude_filter = (?i)^ipmi
+
 ; defines a comma separated list of custom attribute which should be excluded from sync.
 ; Any custom attribute with a matching attribute key will be excluded from sync.
 ;custom_attribute_exclude = VB_LAST_BACKUP, VB_LAST_BACKUP2


### PR DESCRIPTION
## Problem

When a NetBox VM/device carries interfaces that were created by another tool (guest agents, IPAM scripts, manual entry) and those interfaces have no MAC address stored in NetBox, the leftover 1:1 interface matching in `map_object_interfaces_to_current_interfaces()` can match a discovered vNIC onto the wrong NetBox interface, purely based on alphabetical ordering.

Real-world example: a FreeBSD VM has `vmx0` and `tailscale0` interfaces in NetBox (created by an in-guest inventory agent; `tailscale0` is a TUN device with no MAC and no VLAN). vCenter reports one `VirtualVmxnet3` NIC. Name matching fails (`vNIC 1 (portgroup)` matches neither), MAC matching fails (NetBox interfaces carry no MAC), so leftover matching sorts both lists and pairs `vNIC 1 (...)` → `tailscale0` (sorts before `vmx0`). The Tailscale interface then gets the vmxnet3 NIC's MAC address, VLAN, description and the VM's public IPs reassigned onto it.

The guest interface name is not available through the vCenter API (`guest.net` GuestNicInfo has no in-guest device name), so this cannot be solved from source data — the interfaces need to be excludable on the NetBox side.

## Solution

Two new vmware source options (default: unset → behavior unchanged):

* `vm_interface_exclude_filter` — regex; NetBox VM interfaces whose name matches are excluded from all interface matching attempts (name, MAC and leftover 1:1) and are therefore never updated or altered. Discovered interfaces with a matching name are excluded from sync as well (prevents duplicate-create attempts when `sync_vm_dummy_interfaces` is enabled).
* `host_interface_exclude_filter` — same for device (host) interfaces.

Both are compiled by the existing `"filter"`-key branch in `validate_options()` and follow the same semantics as the other filter options (regex, anchored at the start, case sensitive, `|` for multiple expressions).

The check in `map_object_interfaces_to_current_interfaces()` reads the setting via `self.settings`, which safely returns `None` for sources that do not define the option (e.g. check_redfish), so only the vmware source changes behavior.

## Notes

* Users enabling this on an existing setup may want to remove the netbox-sync source/orphaned tags once from interfaces that were previously (mis)matched, so pruning does not consider them orphaned.
* `settings-example.ini` regenerated with `-g`.

Fixes the interface-clobbering aspect discussed in #367 (exceptions for sync_vm_dummy_interfaces) for guest-agent-managed interfaces.

(cherry picked from commit 3966cf48c0bd207a0fe13e51794d5810a5289b4d)