### PR TITLE
Feature: Add vm_status_on_create and vm_status_preserve options

### DIFF
--- a/module/sources/vmware/config.py
+++ b/module/sources/vmware/config.py
@@ -284,6 +284,25 @@ class VMWareConfig(ConfigBase):
                          description="""If an IP address is assigned to a FHRP group (like HSRP, VRRP, GLBP)
                          then this IP address will be skipped and not synced to NetBox to prevent incorrect syncing.""",
                          default_value=False),
+            ConfigOption("vm_status_on_create",
+                         str,
+                         description="""defines the status a VM gets assigned in NetBox when netbox-sync
+                         creates it as a new NetBox VM. Updates of already existing NetBox VMs are not
+                         affected by this option. This way new VMs can start their lifecycle in NetBox
+                         as i.e. 'planned' until changed manually in NetBox.
+                         possible values: offline, active, planned, staged, failed, decommissioning
+                         """,
+                         default_value="active"),
+            ConfigOption("vm_status_preserve",
+                         str,
+                         description="""defines a comma separated list of NetBox VM statuses which will be
+                         preserved on updates. If the current status of an existing NetBox VM matches one of
+                         these values then netbox-sync will not change the status of this VM. This way VMs
+                         can be kept in i.e. 'planned' or 'staged' until changed manually in NetBox.
+                         Set to an empty value to always update the VM status.
+                         possible values: offline, active, planned, staged, failed, decommissioning
+                         """,
+                         default_value="planned, staged, decommissioning"),
             ConfigOption("strip_host_domain_name",
                          bool,
                          description="strip domain part from host name before syncing device to NetBox",
@@ -549,6 +568,28 @@ class VMWareConfig(ConfigBase):
                 if option.value not in ["always", "when-undefined", "never"]:
                     log.error(f"Primary IP option '{option.key}' value '{option.value}' invalid.")
                     self.set_validation_failed()
+
+            # keep in sync with NBVM data_model status values in module/netbox/object_classes.py
+            valid_vm_statuses = ["offline", "active", "planned", "staged", "failed", "decommissioning"]
+
+            if option.key == "vm_status_on_create":
+                option.set_value(option.value.lower())
+                if option.value not in valid_vm_statuses:
+                    log.error(f"Config option '{option.key}' value '{option.value}' invalid. "
+                              f"Possible values: {', '.join(valid_vm_statuses)}")
+                    self.set_validation_failed()
+
+                continue
+
+            if option.key == "vm_status_preserve":
+                option.set_value([x.lower() for x in quoted_split(option.value) or list()])
+                for status_value in option.value:
+                    if status_value not in valid_vm_statuses:
+                        log.error(f"Config option '{option.key}' value '{status_value}' invalid. "
+                                  f"Possible values: {', '.join(valid_vm_statuses)}")
+                        self.set_validation_failed()
+
+                continue
 
             if option.key == "custom_dns_servers":
 

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -1180,6 +1180,11 @@ class VMWareHandler(SourceBase):
         if device_vm_object is None:
             object_name = object_data.get(object_type.primary_key)
             log.debug(f"No existing {object_type.name} object for {object_name}. Creating a new {object_type.name}.")
+
+            if object_type == NBVM and self.settings.vm_status_on_create is not None and \
+                    object_data.get("status") is not None:
+                object_data["status"] = self.settings.vm_status_on_create
+
             device_vm_object = self.inventory.add_object(object_type, data=object_data, source=self)
         else:
 
@@ -1190,6 +1195,16 @@ class VMWareHandler(SourceBase):
             if object_type == NBDevice and self.settings.overwrite_device_platform is False and \
                     object_data.get("platform") is not None:
                 del object_data["platform"]
+
+            if object_type == NBVM and object_data.get("status") is not None:
+                current_status = grab(device_vm_object, "data.status")
+                if isinstance(current_status, dict):
+                    current_status = current_status.get("value")
+                if current_status in (self.settings.vm_status_preserve or list()):
+                    log.debug2(f"Current status '{current_status}' of "
+                               f"'{device_vm_object.get_display_name()}' is in 'vm_status_preserve' list. "
+                               f"Not updating VM status.")
+                    del object_data["status"]
 
             device_vm_object.update(data=object_data, source=self)
 

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -303,6 +303,19 @@ password = super-secret
 ; address will be skipped and not synced to NetBox to prevent incorrect syncing.
 ;skip_fhrp_group_ips = False
 
+; defines the status a VM gets assigned in NetBox when netbox-sync creates it as a new
+; NetBox VM. Updates of already existing NetBox VMs are not affected by this option. This
+; way new VMs can start their lifecycle in NetBox as i.e. 'planned' until changed manually
+; in NetBox. possible values: offline, active, planned, staged, failed, decommissioning
+;vm_status_on_create = active
+
+; defines a comma separated list of NetBox VM statuses which will be preserved on updates.
+; If the current status of an existing NetBox VM matches one of these values then netbox-
+; sync will not change the status of this VM. This way VMs can be kept in i.e. 'planned'
+; or 'staged' until changed manually in NetBox. Set to an empty value to always update the
+; VM status. possible values: offline, active, planned, staged, failed, decommissioning
+;vm_status_preserve = planned, staged, decommissioning
+
 ; strip domain part from host name before syncing device to NetBox
 ;strip_host_domain_name = False
 


### PR DESCRIPTION
## Problem

When a NetBox VM/device carries interfaces that were created by another tool (guest agents, IPAM scripts, manual entry), and/or using netbox as Source of Truth for that information, and those interfaces have no MAC address stored in NetBox, the leftover 1:1 interface matching in `map_object_interfaces_to_current_interfaces()` can match a discovered vNIC onto the wrong NetBox interface, purely based on alphabetical ordering.

Real-world example: a FreeBSD VM has `vmx0` and `tailscale0` interfaces in NetBox (created by an in-guest inventory agent; `tailscale0` is a TUN device with no MAC and no VLAN). vCenter reports one `VirtualVmxnet3` NIC. Name matching fails (`vNIC 1 (portgroup)` matches neither), MAC matching fails (NetBox interfaces carry no MAC), so leftover matching sorts both lists and pairs `vNIC 1 (...)` → `tailscale0` (sorts before `vmx0`). The Tailscale interface then gets the vmxnet3 NIC's MAC address, VLAN, description and the VM's public IPs reassigned onto it.

The guest interface name is not available through the vCenter API (`guest.net` GuestNicInfo has no in-guest device name), so this cannot be solved from source data — the interfaces need to be excludable on the NetBox side.

## Solution

Two new vmware source options (default: unset → behavior unchanged):

* `vm_interface_exclude_filter` — regex; NetBox VM interfaces whose name matches are excluded from all interface matching attempts (name, MAC and leftover 1:1) and are therefore never updated or altered. Discovered interfaces with a matching name are excluded from sync as well (prevents duplicate-create attempts when `sync_vm_dummy_interfaces` is enabled).
* `host_interface_exclude_filter` — same for device (host) interfaces.

Both are compiled by the existing `"filter"`-key branch in `validate_options()` and follow the same semantics as the other filter options (regex, anchored at the start, case sensitive, `|` for multiple expressions).

The check in `map_object_interfaces_to_current_interfaces()` reads the setting via `self.settings`, which safely returns `None` for sources that do not define the option (e.g. check_redfish), so only the vmware source changes behavior.

## Notes

* Users enabling this on an existing setup may want to remove the netbox-sync source/orphaned tags once from interfaces that were previously (mis)matched, so pruning does not consider them orphaned.
* `settings-example.ini` regenerated with `-g`.

Fixes the interface-clobbering aspect discussed in #367 (exceptions for sync_vm_dummy_interfaces) for guest-agent-managed interfaces.


(cherry picked from commit a64bdaa33355fe700508b36cbd0fd0a541be96ce)