### PR TITLE
fixes crash when a VLAN group relation is unresolved

### DIFF
--- a/module/sources/common/source_base.py
+++ b/module/sources/common/source_base.py
@@ -884,7 +884,8 @@ class SourceBase:
             # try find matching VLAN by group
             if grab(vlan, "data.group") is not None:
                 vlan_group = grab(vlan, "data.group")
-                if vlan_group.matches_site_cluster(vlan_site, vlan_cluster):
+                if isinstance(vlan_group, NetBoxObject) and \
+                        vlan_group.matches_site_cluster(vlan_site, vlan_cluster):
                     vlan_object_by_group = vlan
                     break
 


### PR DESCRIPTION
Fixes #529

### Problem

`get_vlan_object_if_exists()` assumes `vlan.data["group"]` is always a resolved `NBVLANGroup` instance:

```python
if grab(vlan, "data.group") is not None:
    vlan_group = grab(vlan, "data.group")
    if vlan_group.matches_site_cluster(vlan_site, vlan_cluster):
```

That holds only for VLAN groups which are part of the inventory netbox-sync fetched itself. For VLANs that already exist in NetBox and whose VLAN group was created by another tool, the relation is never resolved and stays a raw API dict, so the run aborts with:

```
AttributeError: 'dict' object has no attribute 'matches_site_cluster'
```

Since this is raised inside `source.apply()`, it happens **before** `update_instance()` — a failing run writes nothing to NetBox at all, which makes the failure mode rather unpleasant (in our case `virtualization.*` silently stopped being updated for several weeks).

The two other `matches_site_cluster()` call sites (in `add_vlan_group()`) iterate over `self.inventory.get_all_items(NBVLANGroup)` and therefore always operate on real objects — only this one is reachable with an unresolved relation.

### Change

Guard the call with an `isinstance()` check. When the group cannot be resolved, no group match is attempted and the existing site / global VLAN matching applies — the correct degraded behaviour rather than an abort. `NetBoxObject` is already in scope via `from module.netbox import *`.

### Verification

Tested against a production data set: 8 vCenter sources, ~1300 VMs, NetBox 4.6.4 containing ~350 VLAN groups created by an unrelated tool (NetBox Labs orb-agent / Diode).

| | unpatched | patched |
|---|---|---|
| sources processed | 0 of 8 — aborted on the first | **8 of 8** |
| time to abort | ~8 s after the first source started | no abort, full run 1 h 16 min |
| `AttributeError` | reproduced on every run | **0** |

Both runs reached the identical trigger host before diverging, so the guard is what makes the difference. No behaviour change is expected for setups where all VLAN group relations resolve normally.
