### PR TITLE
vmware: add match_vm_by_serial/mac_address/ip_address options

### DIFF
--- a/module/sources/vmware/config.py
+++ b/module/sources/vmware/config.py
@@ -223,6 +223,31 @@ class VMWareConfig(ConfigBase):
                          description="""Try to find existing host based on serial number. This can cause issues
                          with blade centers if VMWare does not report the blades serial number properly.""",
                          default_value=True),
+
+            ConfigOption("match_vm_by_serial",
+                         bool,
+                         description="""Fall back to matching VMs by serial number (BIOS UUID) if no name+cluster
+                         match is found. Can misattribute a VM to an unrelated NetBox object if the same UUID is
+                         reported by multiple sources, e.g. a cloned/migrated VM whose stale copy overwrites the
+                         real VM's cluster/site/status.""",
+                         default_value=True),
+
+            ConfigOption("match_vm_by_mac_address",
+                         bool,
+                         description="""Fall back to matching VMs by vNIC MAC address if no name+cluster match is
+                         found. Runs before 'match_vm_by_serial', so disabling that option alone is not enough if
+                         MACs are also shared. Same misattribution risk as match_vm_by_serial, triggered by a
+                         cloned/copied VM with a duplicate MAC.""",
+                         default_value=True),
+
+            ConfigOption("match_vm_by_ip_address",
+                         bool,
+                         description="""Fall back to matching VMs by primary IP if no name/cluster/MAC/serial
+                         match is found. Same misattribution risk, triggered even transiently, e.g. a duplicate VM
+                         in another cluster briefly powered on with the same IP. Not guaranteed to self-correct
+                         afterwards, since vCenter can keep reporting a cached IP after power-off.""",
+                         default_value=True),
+
             ConfigOption("collect_hardware_asset_tag",
                          bool,
                          description="Attempt to collect asset tags from vCenter hosts",

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -1135,6 +1135,10 @@ class VMWareHandler(SourceBase):
                        (object_type.name, device_vm_object.get_display_name(including_second_key=True)))
 
         # keep searching if no exact match was found
+        elif object_type == NBVM and self.settings.match_vm_by_mac_address is False:
+
+            log.debug2("Matching VMs by MAC address is disabled via 'match_vm_by_mac_address'. Skipping.")
+
         else:
 
             log.debug2(f"No exact match found. Trying to find {object_type.name} based on MAC addresses")
@@ -1162,7 +1166,8 @@ class VMWareHandler(SourceBase):
                                                               data={"asset_tag": object_data.get("asset_tag")})
 
         # look for VMs with same serial
-        if object_type == NBVM and device_vm_object is None and object_data.get("serial") is not None:
+        if object_type == NBVM and device_vm_object is None and object_data.get("serial") is not None and \
+                self.settings.match_vm_by_serial is True:
             log.debug2(f"No match found. Trying to find {object_type.name} based on serial number")
             device_vm_object = self.inventory.get_by_data(object_type, data={"serial": object_data.get("serial")})
 
@@ -1171,6 +1176,10 @@ class VMWareHandler(SourceBase):
                        (object_type.name, device_vm_object.get_display_name(including_second_key=True)))
 
         # keep looking for devices with the same primary IP
+        elif object_type == NBVM and self.settings.match_vm_by_ip_address is False:
+
+            log.debug2("Matching VMs by primary IP address is disabled via 'match_vm_by_ip_address'. Skipping.")
+
         else:
 
             log.debug2(f"No match found. Trying to find {object_type.name} based on primary IP addresses")

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -257,6 +257,24 @@ password = super-secret
 ; centers if VMWare does not report the blades serial number properly.
 ;match_host_by_serial = True
 
+; Fall back to matching VMs by serial number (BIOS UUID) if no name+cluster match is
+; found. Can misattribute a VM to an unrelated NetBox object if the same UUID is reported
+; by multiple sources, e.g. a cloned/migrated VM whose stale copy overwrites the real VM's
+; cluster/site/status.
+;match_vm_by_serial = True
+
+; Fall back to matching VMs by vNIC MAC address if no name+cluster match is found. Runs
+; before 'match_vm_by_serial', so disabling that option alone is not enough if MACs are
+; also shared. Same misattribution risk as match_vm_by_serial, triggered by a
+; cloned/copied VM with a duplicate MAC.
+;match_vm_by_mac_address = True
+
+; Fall back to matching VMs by primary IP if no name/cluster/MAC/serial match is found.
+; Same misattribution risk, triggered even transiently, e.g. a duplicate VM in another
+; cluster briefly powered on with the same IP. Not guaranteed to self-correct afterwards,
+; since vCenter can keep reporting a cached IP after power-off.
+;match_vm_by_ip_address = True
+
 ; Attempt to collect asset tags from vCenter hosts
 ;collect_hardware_asset_tag = True
 


### PR DESCRIPTION

### Summary

VM matching falls through name+cluster → MAC → serial/BIOS UUID → primary IP. Only the serial step has an opt-out (`match_host_by_serial`, host-only) — MAC and IP have none, and none of the three fallbacks are scoped by cluster.

This breaks any setup where a VM is cloned or migrated between vCenters in a way that preserves its MAC, UUID, or IP (common for cross-vCenter migration or cold-copy backups). NetBox itself allows duplicate VM names across different clusters, but netbox-sync doesn't respect that: a stale copy in cluster A fails the name+cluster check, falls through to MAC/serial/IP, matches the *real* VM's object in cluster B, and overwrites its `cluster`/`site`/`status`.

**Net effect**: a VM present in two sources ends up in NetBox once, not twice — silently, with nothing in the log indicating a problem.

### Reproduction

- VM `myvm` is active in `ClusterB` (`cluster=ClusterB`, `status=active`).
- A powered-off duplicate (same MAC/UUID) exists in `ClusterA`, processed first in `settings.ini`.
- `netbox-sync.py -n` reassigns the *same* object:
  ```
  Virtual machine 'myvm' attribute 'cluster' changed from 'ClusterB' to 'ClusterA'
  Virtual machine 'myvm' attribute 'status' changed from 'active' to 'offline'
  Virtual machine 'myvm' attribute 'site' changed from '<ClusterB's site>' to '<ClusterA's site>'
  ```
  Confirmed via the API — one object, not two. Likely affects `NBDevice` too (steps 2–3 apply there), though only tested for VMs.

### Related issues

- **#470** (closed, no fix) — same root cause; this PR fixes it.
- **#472** (open) — same symptom, different cause (case-insensitive cluster-name comparison in step 1). Not fixed here.
- **#428** (closed) — precedent for `match_host_by_serial`, the pattern this PR follows.
- **#498** (open) — different trigger (IP reuse from orphaned VMs), same code path as step 4.
- **PR #523** (open) — step 4 is currently broken by an unrelated bug, so `match_vm_by_ip_address` is a no-op until it merges. Included so it's ready when it does.

### Fix

Three new options mirroring `match_host_by_serial`, all defaulting to `True` (no behavior change unless opted in): `match_vm_by_serial`, `match_vm_by_mac_address`, `match_vm_by_ip_address`.

Tested against NetBox 4.6.7 with ~600 VMs across 4 vCenter sources, including several with genuinely duplicated MAC/serial across clusters. With all three disabled, previously-misattributed VMs now resolve to independent, per-cluster objects; no other object's cluster/site/status changed.

See commit for the full patch (`module/sources/vmware/config.py`, `module/sources/vmware/connection.py`, `settings-example.ini`).
