### PR TITLE
hetzner: stop logging the API token

### DIFF
--- a/module/sources/hetzner/connection.py
+++ b/module/sources/hetzner/connection.py
@@ -72,8 +72,6 @@ class HetznerHandler(SourceBase):
 
         token = self.settings.api_token
 
-        self.log.error(f"TOKEN DEBUG >>> {repr(token)}")
-
         if not token:
             self.log.error("Hetzner api_token not defined in settings.ini")
             return


### PR DESCRIPTION
`HetznerHandler.apply()` logs the configured Hetzner Cloud API token in clear text at ERROR level on every run:

```python
self.log.error(f"TOKEN DEBUG >>> {repr(token)}")
```

Because it is ERROR level, it is emitted regardless of the configured log level and ends up in journald, container stdout and any log shipper. The line is a leftover debug statement from the initial hetzner source (#493).

**Reproduction** (Python 3.14, `development`): calling `apply()` with the log level set to ERROR prints

```
ERROR: TOKEN DEBUG >>> 'hcloud-FAKE-SECRET-TOKEN-0123456789abcdef'
```

before the first API request. After this change the same call prints nothing for a configured token, and the existing missing-token path still reports `Hetzner api_token not defined in settings.ini` without echoing the value.

**Exposure:** the line is not in any tagged release (`main` / v1.8.1 predate #493), but it is on `development` and therefore in the container image built from that branch. Anyone running the hetzner source from `development` should assume the token has been written to their logs and rotate it. I would suggest a note to that effect in the v1.9.0 release notes.

While checking the code-scanning findings I also confirmed that no other log call formats a token or password; the seven open CodeQL alerts are all the same pattern (MAC addresses flowing into generic `got: '{value}'` diagnostics), which is inventory data this tool exists to sync rather than a secret. I will summarize that separately.