### PR TITLE
bumps idna to 3.15 and setuptools to 83.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pyvmomi==9.1.0.0",
     "pyyaml>=6.0.3",
     "requests>=2.34.2",
-    "setuptools==82.0.1",
+    "setuptools==83.0.0",
     "urllib3>=2.7.0",
     "wheel>=0.47.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ certifi==2026.1.4
 cffi==2.0.0
 charset-normalizer==3.4.4
 hcloud==2.20.0
-idna==3.11
+idna==3.15
 packaging==26.2
 pycares==5.0.1
 pycparser==3.0
@@ -11,7 +11,7 @@ python-dateutil==2.9.0.post0
 pyvmomi==9.1.0.0
 pyyaml==6.0.3
 requests==2.34.2
-setuptools==82.0.1
+setuptools==83.0.0
 six==1.17.0
 urllib3==2.7.0
 wheel==0.47.0

--- a/uv.lock
+++ b/uv.lock
@@ -128,11 +128,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -159,7 +159,7 @@ requires-dist = [
     { name = "pyvmomi", specifier = "==9.1.0.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "requests", specifier = ">=2.34.2" },
-    { name = "setuptools", specifier = "==82.0.1" },
+    { name = "setuptools", specifier = "==83.0.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "wheel", specifier = ">=0.47.0" },
 ]
@@ -302,11 +302,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes the two open Dependabot findings that still apply to `development`:

| package | from | to | advisory |
| --- | --- | --- | --- |
| idna | 3.11 | 3.15 | CVE-2026-45409 / GHSA-65pc-fj4g-8rjx, crafted input to `idna.encode()` bypasses the CVE-2024-3651 length check and burns CPU (medium, CVSS 5.3) |
| setuptools | 82.0.1 | 83.0.0 | CVE-2026-59890 / GHSA-h35f-9h28-mq5c, `MANIFEST.in` exclusion bypass via NFC/NFD collision (medium, CVSS 6.1) |

Changes: `requirements.txt`, the `setuptools` pin in `pyproject.toml`, and `uv.lock` regenerated with `uv lock --upgrade-package` for just these two packages (the lock diff touches nothing else). setuptools 83 requires Python 3.10+, within the project's 3.13 floor.

The urllib3 and requests alerts in the Dependabot tab are reported against `main` (v1.8.1); `development` already carries 2.7.0 and 2.34.2, so they close with the next release.

**Verification**

- Clean Python 3.14 environment built the way the Dockerfile does it (`pip install -r requirements.txt`, then `pip install --upgrade vcf-sdk`): `pip-audit` goes from 4 findings in 2 packages (idna, setuptools) to none.
- `pip freeze` before vs after differs in exactly these two packages.
- The vSphere automation SDK imports as before (`com.vmware.vapi.std_client`, `vmware.vapi.vsphere.client`), `vsphere_automation_sdk_available` is `True`, and `create_vsphere_client()` gets as far as the network call. Regarding #497: `vmware-vapi-runtime` 9.1.0.0 resolves versions through `importlib.metadata` and only falls back to `pkg_resources` inside an `except`, so setuptools without `pkg_resources` is fine here (it already is on `development` with 82.0.1).
- The unit tests from #538 pass against the bumped environment.
- Real `docker build --platform linux/amd64` of the Dockerfile with these pins succeeds; inside the image: setuptools 83.0.0, idna 3.15, urllib3 2.7.0, requests 2.34.2, the SDK import works, `netbox-sync.py --help` runs, and `pip-audit` over the image's installed packages reports no known vulnerabilities.