### PR TITLE
fix: stops structured values being stringified into component names

### DIFF
--- a/module/common/misc.py
+++ b/module/common/misc.py
@@ -159,6 +159,8 @@ def get_string_or_none(text=None):
     """
     Only return stripped content of text if text is not None and not empty
 
+    A structured value is not a name and returns None. Scalars, including ints, still stringify.
+
     Parameters
     ----------
     text: str
@@ -168,6 +170,9 @@ def get_string_or_none(text=None):
     -------
     (str, None): content of text
     """
+
+    if isinstance(text, (dict, list, set, tuple)):
+        return None
 
     if text is not None and len(str(text).strip()) > 0:
         return str(text).strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,10 @@ dependencies = [
 [project.urls]
 Repository = "https://github.com/bb-ricardo/netbox-sync.git"
 Issues = "https://github.com/bb-ricardo/netbox-sync/issues"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"
+# the modules under test live in the repository root, which plain `pytest` does
+# not put on sys.path (unlike `python -m pytest`)
+pythonpath = ["."]

--- a/tests/test_check_redfish_inventory_items.py
+++ b/tests/test_check_redfish_inventory_items.py
@@ -1,0 +1,100 @@
+"""Integration tests for the check_redfish source and the inventory items it maintains.
+
+Drives the real CheckRedfish methods against the real NetBoxInventory and NetBoxObject
+classes. Only the NetBox REST API itself is out of scope.
+"""
+
+import types
+
+from module.netbox.inventory import NetBoxInventory
+from module.netbox.object_classes import NBDevice, NBInventoryItem
+from module.sources.check_redfish.import_inventory import CheckRedfish
+
+
+def make_source():
+    """Build a CheckRedfish source on a fresh inventory, with the real base objects registered."""
+
+    inventory = NetBoxInventory()
+    # reset the singleton state so each test starts from an empty inventory
+    inventory.init()
+    inventory.source_list = list()
+    inventory.netbox_api_version = "4.3.0"
+
+    source = object.__new__(CheckRedfish)
+    source.inventory = inventory
+    source.name = "test"
+    source.source_tag = "Source: test"
+    source.settings = types.SimpleNamespace()
+
+    source.add_necessary_base_objects()
+
+    device = inventory.add_object(NBDevice, data={"name": "server01"}, source=source)
+    source.device_object = device
+
+    return source, inventory, device
+
+
+# a Dell `location` as check_redfish can hand it back: a nested Oem object, not a string
+DELL_LOCATION = {
+    "Oem": {
+        "Dell": {
+            "@odata.type": "#DellLocation.v1_2_0.DellLocation",
+            "Locator": "BP_PSV 0:1",
+        }
+    }
+}
+
+
+def enclosure(name, location, serial="ENC-AAA"):
+    return {"inventory": {"storage_enclosure": [
+        {"name": name, "model": "BP14G+EXP", "location": location,
+         "manufacturer": "DELL", "serial": serial, "part_number": "PN-ENC",
+         "firmware": "1.0", "health_status": "OK", "num_bays": 24,
+         "operation_status": "Enabled"}]}}
+
+
+def test_structured_location_is_not_stringified_into_the_item_name():
+    """A structured location must not reach the name as its Python repr."""
+
+    source, inventory, _ = make_source()
+
+    source.inventory_file_content = enclosure("BP_PSV 0:1", DELL_LOCATION)
+    source.update_storage_enclosure()
+
+    items = inventory.get_all_items(NBInventoryItem)
+    assert len(items) == 1
+
+    name = items[0].data["name"]
+    assert "Oem" not in name
+    assert "@odata.type" not in name
+    assert "{" not in name
+    assert len(name) <= 64
+    assert name == "BP_PSV 0:1"
+
+
+def test_plain_string_location_is_kept_in_the_item_name():
+    """A location that really is a string is still used."""
+
+    source, inventory, _ = make_source()
+
+    source.inventory_file_content = enclosure("BP_PSV 0:1", "Slot 3")
+    source.update_storage_enclosure()
+
+    items = inventory.get_all_items(NBInventoryItem)
+    assert len(items) == 1
+    assert items[0].data["name"] == "BP_PSV 0:1 Slot 3"
+
+
+def test_two_enclosures_with_structured_locations_stay_distinct():
+    """Dropping the unusable location must not merge two enclosures onto one name."""
+
+    source, inventory, _ = make_source()
+
+    source.inventory_file_content = {"inventory": {"storage_enclosure": [
+        enclosure("BP_PSV 0:1", DELL_LOCATION, "ENC-AAA")["inventory"]["storage_enclosure"][0],
+        enclosure("BP_PSV 0:2", DELL_LOCATION, "ENC-BBB")["inventory"]["storage_enclosure"][0],
+    ]}}
+    source.update_storage_enclosure()
+
+    names = sorted(item.data["name"] for item in inventory.get_all_items(NBInventoryItem))
+    assert names == ["BP_PSV 0:1", "BP_PSV 0:2"]

--- a/tests/test_common_misc.py
+++ b/tests/test_common_misc.py
@@ -1,0 +1,35 @@
+"""Tests for the shared parsing helpers in module/common/misc.py."""
+
+from module.common.misc import get_string_or_none
+
+# A Dell structured `location` blob as check_redfish can hand it back: not a plain string but a
+# nested Oem dict. str()-ing it produces ~200 chars of "{'Oem': {'Dell': {'@odata.type': ...}}}".
+DELL_LOCATION = {
+    "Oem": {
+        "Dell": {
+            "@odata.type": "#DellLocation.v1_2_0.DellLocation",
+            "Locator": "BP_PSV 0:1",
+        }
+    }
+}
+
+
+def test_get_string_or_none_rejects_structured_values():
+    """A nested dict/list is not a meaningful name and must not be stringified into one."""
+
+    assert get_string_or_none(DELL_LOCATION) is None
+    assert get_string_or_none(["a", "b"]) is None
+    assert get_string_or_none(("a",)) is None
+    assert get_string_or_none({1, 2}) is None
+
+
+def test_get_string_or_none_keeps_scalar_behavior():
+    """Scalars are unchanged. Many callers pass ints (core counts, slot numbers, port counts)
+    and rely on them stringifying."""
+
+    assert get_string_or_none("  Slot 5 ") == "Slot 5"
+    assert get_string_or_none(5) == "5"
+    assert get_string_or_none(0) == "0"
+    assert get_string_or_none(None) is None
+    assert get_string_or_none("") is None
+    assert get_string_or_none("   ") is None


### PR DESCRIPTION
get_string_or_none() is the shared parser for every name and label the check_redfish source builds. It str()-ed whatever it was given, so a value that is not a string was turned into its Python repr and concatenated into the name.

Dell iDRAC returns the `location` of a storage enclosure, storage controller or physical drive as a nested Oem object rather than a string:

```
    {'Oem': {'Dell': {'@odata.type': '#DellLocation.v1_2_0.DellLocation', ...}}}
```

The inventory item was then named 
```
"BP_PSV 0:1 {'Oem': {'Dell': {'@odata.type': '#Del", 
```
NetBox storing the first 64 characters of it. The name is unreadable and the location it was meant to carry is lost.

get_string_or_none() now returns None for dict/list/set/tuple, so an unusable value is dropped instead of being pasted into the name. Scalars are untouched: the helper has many callers which pass ints (core counts, slot numbers, port counts) and rely on them stringifying.

added  [tool.pytest.ini_options] to pyproject.toml, same as in #541 so it can drop when that merges. make_source() helper can move to conftest as well at that point.