### PR TITLE
fix: stops orphan tagging redfish inventory items the source still manages

### DIFF
--- a/module/sources/check_redfish/import_inventory.py
+++ b/module/sources/check_redfish/import_inventory.py
@@ -311,7 +311,6 @@ class CheckRedfish(SourceBase):
 
             # compile inventory item data
             ps_items.append({
-                "inventory_type": "Power Supply",
                 "health": health_status,
                 "description": description,
                 "full_name": name,
@@ -358,7 +357,7 @@ class CheckRedfish(SourceBase):
 
             ps_index += 1
 
-        self.update_all_items(ps_items)
+        self.update_all_items(ps_items, "Power Supply")
 
     def update_fan(self):
 
@@ -385,14 +384,13 @@ class CheckRedfish(SourceBase):
                 speed = f"{reading}{reading_unit}"
 
             items.append({
-                "inventory_type": "Fan",
                 "description": description,
                 "full_name": f"{fan_name} (ID: {fan_id})",
                 "health": health_status,
                 "speed": speed
             })
 
-        self.update_all_items(items)
+        self.update_all_items(items, "Fan")
 
     def update_memory(self):
 
@@ -436,7 +434,6 @@ class CheckRedfish(SourceBase):
                 speed = f"{speed}MHz"
 
             items.append({
-                "inventory_type": "DIMM",
                 "description": description,
                 "full_name": name or "None",
                 "serial": get_string_or_none(grab(memory, "serial")),
@@ -447,7 +444,7 @@ class CheckRedfish(SourceBase):
                 "speed": speed,
             })
 
-        self.update_all_items(items)
+        self.update_all_items(items, "DIMM")
 
         if memory_size_total > 0:
             memory_size_total = memory_size_total / 1024
@@ -496,7 +493,6 @@ class CheckRedfish(SourceBase):
                 description.append(f"Threads: {threads}")
 
             items.append({
-                "inventory_type": "CPU",
                 "description": description,
                 "manufacturer": get_string_or_none(grab(processor, "manufacturer")),
                 "full_name": name,
@@ -506,7 +502,7 @@ class CheckRedfish(SourceBase):
                 "speed": current_speed
             })
 
-        self.update_all_items(items)
+        self.update_all_items(items, "CPU")
 
         if num_cores > 0:
             custom_fields_data = {"custom_fields": {"host_cpu_cores": f"{num_cores} {cpu_name}"}}
@@ -568,7 +564,6 @@ class CheckRedfish(SourceBase):
                 speed = f"{speed_in_rpm}RPM"
 
             items.append({
-                "inventory_type": "Physical Drive",
                 "description": description,
                 "manufacturer": get_string_or_none(grab(pd, "manufacturer")),
                 "full_name": name or "None",
@@ -580,7 +575,7 @@ class CheckRedfish(SourceBase):
                 "speed": speed
             })
 
-        self.update_all_items(items)
+        self.update_all_items(items, "Physical Drive")
 
     def update_storage_controller(self):
 
@@ -614,7 +609,6 @@ class CheckRedfish(SourceBase):
                 size = f"{cache_size_in_mb}MB"
 
             items.append({
-                "inventory_type": "Storage Controller",
                 "description": description,
                 "manufacturer": get_string_or_none(grab(sc, "manufacturer")),
                 "full_name": name or "None",
@@ -624,7 +618,7 @@ class CheckRedfish(SourceBase):
                 "size": size
             })
 
-        self.update_all_items(items)
+        self.update_all_items(items, "Storage Controller")
 
     def update_storage_enclosure(self):
 
@@ -650,7 +644,6 @@ class CheckRedfish(SourceBase):
                 size = f"Bays: {num_bays}"
 
             items.append({
-                "inventory_type": "Storage Enclosure",
                 "manufacturer": get_string_or_none(grab(se, "manufacturer")),
                 "full_name": name or "None",
                 "serial": get_string_or_none(grab(se, "serial")),
@@ -659,7 +652,7 @@ class CheckRedfish(SourceBase):
                 "size": size
             })
 
-        self.update_all_items(items)
+        self.update_all_items(items, "Storage Enclosure")
 
     def update_network_adapter(self):
 
@@ -710,7 +703,6 @@ class CheckRedfish(SourceBase):
                 self.interface_adapter_type_dict[adapter_id] = nic_type
 
             items.append({
-                "inventory_type": "NIC",
                 "manufacturer": manufacturer,
                 "full_name": name,
                 "serial": serial,
@@ -721,7 +713,7 @@ class CheckRedfish(SourceBase):
                 "speed": nic_type.get_speed_human()
             })
 
-        self.update_all_items(items)
+        self.update_all_items(items, "NIC")
 
     def update_network_interface(self):
 
@@ -900,7 +892,6 @@ class CheckRedfish(SourceBase):
                 description = f"Licenses: %s" % (", ".join(licenses))
 
             items.append({
-                "inventory_type": "Manager",
                 "description": description,
                 "full_name": name,
                 "manufacturer": grab(self.device_object, "data.device_type.data.manufacturer.data.name"),
@@ -908,9 +899,9 @@ class CheckRedfish(SourceBase):
                 "health": get_string_or_none(grab(manager, "health_status"))
             })
 
-        self.update_all_items(items)
+        self.update_all_items(items, "Manager")
 
-    def update_all_items(self, items):
+    def update_all_items(self, items, inventory_type):
         """
         Updates all inventory items of a certain type. Both (current and supplied list of items) will
         be sorted by name and matched 1:1.
@@ -919,6 +910,9 @@ class CheckRedfish(SourceBase):
         ----------
         items: list
             a list of items to update
+        inventory_type: str
+            the component type this batch is about (CPU, DIMM, Fan, ...), stated by the caller
+            so an empty batch still says which components are gone
 
         Returns
         -------
@@ -928,15 +922,9 @@ class CheckRedfish(SourceBase):
         if not isinstance(items, list):
             raise ValueError(f"Value for 'items' must be type 'list' got: {items}")
 
-        if len(items) == 0:
-            return
-
-        # get device
-        inventory_type = grab(items, "0.inventory_type")
-
-        if inventory_type is None:
-            log.error(f"Unable to find inventory type for inventory item {items[0]}")
-            return
+        # stamp the type so the lookup value and the stored value cannot drift apart
+        for item in items:
+            item["inventory_type"] = inventory_type
 
         # get current inventory items for this device and type
         current_inventory_items = dict()
@@ -977,8 +965,8 @@ class CheckRedfish(SourceBase):
                 if len(unmatched_inventory_items) > 0:
                     matched_inventory[nb_inventory_item] = unmatched_inventory_items.pop(0)
 
-                # set item health to absent if item can't be found in redfish inventory anymore
-                elif grab(nb_inventory_item, "data.custom_fields.health") != "Absent":
+                # unconditional: an object a run does not touch is tagged orphaned
+                else:
                     nb_inventory_item.update(data={"custom_fields": {"health": "Absent"}}, source=self)
 
         # update items with matching NetBox inventory item

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,10 @@ dependencies = [
 [project.urls]
 Repository = "https://github.com/bb-ricardo/netbox-sync.git"
 Issues = "https://github.com/bb-ricardo/netbox-sync/issues"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"
+# the modules under test live in the repository root, which plain `pytest` does
+# not put on sys.path (unlike `python -m pytest`)
+pythonpath = ["."]

--- a/tests/test_check_redfish_orphan_tagging.py
+++ b/tests/test_check_redfish_orphan_tagging.py
@@ -1,0 +1,121 @@
+"""Inventory items the check_redfish source still manages must not be tagged orphaned.
+
+Drives the real CheckRedfish methods and the real tag_all_the_things() against the real
+NetBoxInventory. Only the NetBox REST API itself is out of scope.
+"""
+
+import types
+
+from module.netbox.connection import NetBoxHandler
+from module.netbox.inventory import NetBoxInventory
+from module.netbox.object_classes import NBDevice, NBInventoryItem, NBTag
+from module.sources.check_redfish.import_inventory import CheckRedfish
+
+
+def make_source():
+    """Build a CheckRedfish source on a fresh inventory, with the real base objects registered."""
+
+    inventory = NetBoxInventory()
+    # reset the singleton state so each test starts from an empty inventory
+    inventory.init()
+    inventory.source_list = list()
+    inventory.netbox_api_version = "4.3.0"
+
+    source = object.__new__(CheckRedfish)
+    source.inventory = inventory
+    source.name = "test"
+    source.source_tag = "Source: test"
+    source.settings = types.SimpleNamespace()
+
+    source.add_necessary_base_objects()
+    # the primary tag is normally registered by the NetBox handler, not by the source
+    inventory.add_update_object(NBTag, data={"name": NetBoxHandler.primary_tag})
+
+    device = inventory.add_object(NBDevice, data={"name": "server01"}, source=source)
+    source.device_object = device
+
+    return source, inventory, device
+
+
+def make_netbox_handler():
+    """A NetBoxHandler carrying only what tag_all_the_things() reads, with the real tag names."""
+
+    handler = object.__new__(NetBoxHandler)
+    handler.settings = types.SimpleNamespace(ignore_unknown_source_object_pruning=False)
+    return handler
+
+
+def existing_item(source, device, name, inventory_type, health="OK"):
+    """Seed an item the way query_current_data() does: read from NetBox, tagged, unclaimed."""
+
+    item = source.inventory.add_object(NBInventoryItem, data={
+        "device": device,
+        "name": name,
+        "custom_fields": {"inventory_type": inventory_type, "health": health},
+    }, read_from_netbox=True)
+    item.add_tags([NetBoxHandler.primary_tag, source.source_tag])
+    item.source = None
+    item.updated_items = list()
+    return item
+
+
+def test_components_are_marked_absent_when_the_scan_reports_none_of_their_type():
+    """A scan reporting no fan says the fans are gone, so they must be marked absent."""
+
+    source, inventory, device = make_source()
+    source.inventory.source_list.append(source)
+    fan = existing_item(source, device, "Fan 1 (ID: 1)", "Fan")
+
+    source.inventory_file_content = {"inventory": {"fan": []}}
+    source.update_fan()
+
+    assert fan.data["custom_fields"]["health"] == "Absent"
+    assert fan.source is source, "the run must claim the item, or it is tagged orphaned"
+
+    inventory.tag_all_the_things(make_netbox_handler())
+    assert NetBoxHandler.orphaned_tag not in fan.get_tags()
+
+
+def test_components_already_absent_are_claimed_again_on_every_run():
+    """An item already at absent must still be claimed, or it is tagged orphaned."""
+
+    source, inventory, device = make_source()
+    source.inventory.source_list.append(source)
+    fan = existing_item(source, device, "Fan 1 (ID: 1)", "Fan", health="Absent")
+
+    source.inventory_file_content = {"inventory": {"fan": []}}
+    source.update_fan()
+
+    assert fan.source is source, "an already absent item must still be claimed by the run"
+
+    inventory.tag_all_the_things(make_netbox_handler())
+    assert NetBoxHandler.orphaned_tag not in fan.get_tags()
+
+
+def test_components_of_another_type_are_left_alone():
+    """An empty fan batch says nothing about the CPUs, which must not be marked absent."""
+
+    source, inventory, device = make_source()
+    source.inventory.source_list.append(source)
+    cpu = existing_item(source, device, "Socket 1", "CPU")
+
+    source.inventory_file_content = {"inventory": {"fan": []}}
+    source.update_fan()
+
+    assert cpu.data["custom_fields"]["health"] == "OK"
+
+
+def test_reported_components_are_still_updated_normally():
+    """The empty batch handling must not disturb the ordinary path."""
+
+    source, inventory, device = make_source()
+
+    source.inventory_file_content = {"inventory": {"fan": [
+        {"name": "Fan 1", "id": "1", "health_status": "OK", "operation_status": "Enabled",
+         "physical_context": "CPU", "reading": 4200, "reading_unit": "RPM"}]}}
+    source.update_fan()
+
+    items = inventory.get_all_items(NBInventoryItem)
+    assert len(items) == 1
+    assert items[0].data["custom_fields"]["health"] == "OK"
+    assert items[0].data["custom_fields"]["inventory_type"] == "Fan"


### PR DESCRIPTION
## Problem

`tag_all_the_things()` adds the orphaned tag to every object which carries the primary tag and which a run does not register with its source. Two paths in the check_redfish source left inventory items untouched, so they were tagged orphaned while the source was still managing them.

**1. An empty batch said nothing.** `update_all_items()` read the component type back from the first item in the batch and returned early on an empty list:

```python
if len(items) == 0:
    return

inventory_type = grab(items, "0.inventory_type")
```

A scan which reports no component of a type therefore left every one of that device's components of that type untouched, instead of marking them absent. A server whose fans stop being reported is the case which shows it.

**2. Already absent items were never touched again.** Marking an item absent was conditional on its health actually changing:

```python
elif grab(nb_inventory_item, "data.custom_fields.health") != "Absent":
```

So an item already at absent was skipped on every later run, and tagged orphaned from then on.

## Fix

The component type is passed in by the caller, which knows it whether or not the batch is empty, and is stamped onto the items in `update_all_items()`, so the value used for the lookup and the value stored on each item cannot drift apart.

Registering the item with the source is now unconditional. `update()` still writes nothing when the value is unchanged, so this adds no NetBox requests.


## Notes

- Changes the `update_all_items()` signature and drops the per-item `inventory_type` key at the nine call sites.
- Adds `[tool.pytest.ini_options]` to `pyproject.toml`
- The `make_source()` helper - should be moved to `tests/conftest.py` when available (I see it in #541)