### PR TITLE
fix: accept an API token that already carries its scheme

### DIFF
--- a/module/netbox/connection.py
+++ b/module/netbox/connection.py
@@ -9,6 +9,7 @@
 
 import json
 import os
+import re
 import pickle
 import pprint
 from datetime import datetime
@@ -152,7 +153,10 @@ class NetBoxHandler:
         requests.Session: session handler of new NetBox session
         """
 
-        token = self.settings.api_token
+        # the config value is the bare token; a scheme typed in front of it
+        # ("Bearer nbt_...", "Token abc...") must not be sent twice
+        token = re.sub(r"^\s*(?:bearer|token)\s+", "", str(self.settings.api_token), flags=re.IGNORECASE).strip()
+        # NetBox 4.5+ API tokens (nbt_<key>.<token>) use the Bearer scheme
         keyword = "Bearer" if token.startswith("nbt_") else "Token"
         header = {
             "Authorization": f"{keyword} {token}",

--- a/tests/test_netbox_token_header.py
+++ b/tests/test_netbox_token_header.py
@@ -1,0 +1,43 @@
+"""
+The NetBox API token from the config is sent with the right scheme (issue #513).
+
+NetBox 4.5+ tokens (nbt_<key>.<token>) use "Bearer", legacy tokens use "Token".
+A scheme typed into the config value itself must not be sent twice.
+"""
+import pytest
+
+from module.netbox.connection import NetBoxHandler
+
+
+class _Settings:
+    def __init__(self, api_token):
+        self.api_token = api_token
+
+    def __getattr__(self, name):  # any other setting create_session might look at
+        return None
+
+
+def _authorization(token):
+    # skip __init__: it parses the config and talks to NetBox
+    handler = object.__new__(NetBoxHandler)
+    handler.settings = _Settings(token)
+    return handler.create_session().headers["Authorization"]
+
+
+def test_legacy_token_uses_the_token_scheme():
+    assert _authorization("0123456789abcdef0123456789abcdef01234567") == \
+        "Token 0123456789abcdef0123456789abcdef01234567"
+
+
+def test_v2_token_uses_the_bearer_scheme():
+    assert _authorization("nbt_abc.def") == "Bearer nbt_abc.def"
+
+
+@pytest.mark.parametrize("configured, expected", [
+    ("Bearer nbt_abc.def", "Bearer nbt_abc.def"),
+    ("bearer nbt_abc.def", "Bearer nbt_abc.def"),
+    ("Token 0123abcd", "Token 0123abcd"),
+    ("token  0123abcd", "Token 0123abcd"),
+])
+def test_scheme_in_the_config_value_is_not_sent_twice(configured, expected):
+    assert _authorization(configured) == expected


### PR DESCRIPTION
Follow-up to #513.

`development` already sends NetBox 4.5+ tokens (`nbt_<key>.<token>`) with the `Bearer` scheme. If the configured value itself starts with a scheme, as in the report (`api_token = Bearer nbt_...`), the header became `Token Bearer nbt_...` and NetBox rejected it. A leading `Bearer`/`Token` in the value is now stripped before the scheme is chosen, so both spellings work.

Tests: `tests/test_netbox_token_header.py` covers legacy and `nbt_` tokens and the scheme-in-value cases (the latter fail on `development`, pass with the fix). Full suite green.