### PR TITLE
Feature/dell serial from service tag

### DIFF
--- a/module/sources/check_redfish/config.py
+++ b/module/sources/check_redfish/config.py
@@ -46,6 +46,14 @@ class CheckRedfishConfig(ConfigBase):
                          overwrites the device host name in NetBox""",
                          default_value=False),
 
+            ConfigOption("dell_serial_from_service_tag",
+                         bool,
+                         description="""for Dell devices, use the Service Tag as the NetBox device
+                         serial number (matching what dmidecode and the OS report) instead of the
+                         system serial number. The original system serial number (the Dell PPID)
+                         is then stored in the 'system_serial' custom field""",
+                         default_value=False),
+
             ConfigOption("overwrite_power_supply_name",
                          bool,
                          description="""define if the name of the power supply discovered via check_redfish

--- a/module/sources/check_redfish/import_inventory.py
+++ b/module/sources/check_redfish/import_inventory.py
@@ -107,41 +107,8 @@ class CheckRedfish(SourceBase):
             if self.read_inventory_file_content(filename) is False:
                 continue
 
-            # try to get device by supplied NetBox id
-            inventory_id = grab(self.inventory_file_content, "meta.inventory_id")
-
-            # parse inventory id to int as all NetBox ids are type integer
-            try:
-                inventory_id = int(inventory_id)
-            except (ValueError, TypeError):
-                log.warning(f"Value for meta.inventory_id '{inventory_id}' must be an integer. "
-                            f"Cannot use inventory_id to match device in NetBox.")
-
-            self.device_object = self.inventory.get_by_id(NBDevice, inventory_id)
-
-            if self.device_object is not None:
-                log.debug2("Found a matching %s object '%s' based on inventory id '%d'" %
-                           (self.device_object.name,
-                            self.device_object.get_display_name(including_second_key=True),
-                            inventory_id))
-
-            else:
-                # try to find device by serial of first system in inventory
-                device_serial = grab(self.inventory_file_content, "inventory.system.0.serial")
-                if self.device_object is None:
-                    self.device_object = self.inventory.get_by_data(NBDevice, data={
-                        "serial": device_serial
-                    })
-
-                if self.device_object is None:
-                    log.error(f"Unable to find {NBDevice.name} with id '{inventory_id}' or "
-                              f"serial '{device_serial}' in NetBox inventory from inventory file {filename}")
-                    continue
-                else:
-                    log.debug2("Found a matching %s object '%s' based on serial '%s'" %
-                               (self.device_object.name,
-                                self.device_object.get_display_name(including_second_key=True),
-                                device_serial))
+            if self.find_device_object(filename) is False:
+                continue
 
             # parse all components
             self.update_device()
@@ -155,6 +122,78 @@ class CheckRedfish(SourceBase):
             self.update_storage_enclosure()
             self.update_network_adapter()
             self.update_network_interface()
+
+    def find_device_object(self, filename):
+        """
+        Match the current inventory file to a NetBox device and store it in self.device_object.
+        Tried in order: meta.inventory_id, the system serial, then the Dell Service Tag.
+
+        Parameters
+        ----------
+        filename: str
+            inventory file name, used for logging only
+
+        Returns
+        -------
+        bool: True if a matching device was found
+        """
+
+        supplied_id = grab(self.inventory_file_content, "meta.inventory_id")
+        inventory_id = None
+
+        # bool is a subclass of int and float truncates, so int() would turn both `true` and
+        # `1.9` into the id of a real but unrelated device
+        if isinstance(supplied_id, bool) or not isinstance(supplied_id, (int, str)):
+            parsed_id = None
+        else:
+            try:
+                parsed_id = int(str(supplied_id).strip())
+            except ValueError:
+                parsed_id = None
+
+        if parsed_id is not None and parsed_id > 0:
+            inventory_id = parsed_id
+        elif supplied_id is not None:
+            # an absent id is the normal case, so only warn about a supplied one which is unusable
+            log.warning(f"Value for meta.inventory_id '{supplied_id}' must be a positive integer. "
+                        f"Cannot use inventory_id to match device in NetBox.")
+
+        self.device_object = None
+        if inventory_id is not None:
+            self.device_object = self.inventory.get_by_id(NBDevice, inventory_id)
+
+        if self.device_object is not None:
+            log.debug2("Found a matching %s object '%s' based on inventory id '%d'" %
+                       (self.device_object.name,
+                        self.device_object.get_display_name(including_second_key=True),
+                        inventory_id))
+            return True
+
+        # normalize as update_device() stores it, and never probe serial=None: get_by_data()
+        # compares dicts exactly, so it would match a device which has no serial at all
+        device_serial = get_string_or_none(grab(self.inventory_file_content, "inventory.system.0.serial"))
+        if device_serial is not None:
+            self.device_object = self.inventory.get_by_data(NBDevice, data={"serial": device_serial})
+
+        # unconditional, so disabling the option cannot strand a device already persisted
+        # with its Service Tag as the serial. get_service_tag() self-gates on the vendor.
+        if self.device_object is None:
+            service_tag = self.get_service_tag()
+            if service_tag is not None:
+                self.device_object = self.inventory.get_by_data(NBDevice, data={"serial": service_tag})
+                if self.device_object is not None:
+                    device_serial = service_tag
+
+        if self.device_object is None:
+            log.error(f"Unable to find {NBDevice.name} with id '{inventory_id}' or "
+                      f"serial '{device_serial}' in NetBox inventory from inventory file {filename}")
+            return False
+
+        log.debug2("Found a matching %s object '%s' based on serial '%s'" %
+                   (self.device_object.name,
+                    self.device_object.get_display_name(including_second_key=True),
+                    device_serial))
+        return True
 
     def reset_inventory_state(self):
         """
@@ -209,6 +248,22 @@ class CheckRedfish(SourceBase):
 
         return True
 
+    def get_service_tag(self):
+        """
+        Return the Dell Service Tag (the chassis SKU), or None when this is not a Dell or no
+        Service Tag is reported. Shared so matching and updating agree on the value.
+
+        Returns
+        -------
+        (str, None): the Dell Service Tag
+        """
+
+        manufacturer = get_string_or_none(grab(self.inventory_file_content, "inventory.system.0.manufacturer"))
+        if manufacturer is None or "dell" not in manufacturer.lower():
+            return None
+
+        return get_string_or_none(grab(self.inventory_file_content, "inventory.chassis.0.sku"))
+
     def update_device(self):
 
         system = grab(self.inventory_file_content, "inventory.system.0")
@@ -217,7 +272,7 @@ class CheckRedfish(SourceBase):
             log.error(f"No system data found for '{self.device_object.get_display_name()}' in inventory file.")
             return
 
-        serial = get_string_or_none(grab(system, "serial"))
+        system_serial = get_string_or_none(grab(system, "serial"))
         name = get_string_or_none(grab(system, "host_name"))
         manufacturer = get_string_or_none(grab(system, "manufacturer"))
 
@@ -234,13 +289,13 @@ class CheckRedfish(SourceBase):
             }
         }
 
-        if serial is not None:
-            device_data["serial"] = serial
+        serial = system_serial
+
         if name is not None and self.settings.overwrite_host_name is True:
             device_data["name"] = name
         if "dell" in str(manufacturer).lower():
-            chassis = grab(self.inventory_file_content, "inventory.chassis.0")
-            if chassis and "sku" in chassis:
+            service_tag = self.get_service_tag()
+            if service_tag is not None:
 
                 # add ServiceTag
                 self.add_update_custom_field({
@@ -253,10 +308,30 @@ class CheckRedfish(SourceBase):
                     "description": "Dell Service Tag"
                 })
 
-                device_data["custom_fields"]["service_tag"] = chassis.get("sku")
+                device_data["custom_fields"]["service_tag"] = service_tag
+
+                if grab(self.settings, "dell_serial_from_service_tag", fallback=False) is True:
+                    serial = service_tag
+
+                    # custom fields are merged, not None-skipped, so a missing value would clear it
+                    if system_serial is not None:
+                        self.add_update_custom_field({
+                            "name": "system_serial",
+                            "label": "System Serial Number",
+                            "object_types": [
+                                "dcim.device"
+                            ],
+                            "type": "text",
+                            "description": "System serial number reported by the BMC (Dell PPID)"
+                        })
+
+                        device_data["custom_fields"]["system_serial"] = system_serial
             else:
                 log.warning(f"No chassis or sku data found for "
                             f"'{self.device_object.get_display_name()}' in inventory file.")
+
+        if serial is not None:
+            device_data["serial"] = serial
 
         self.device_object.update(data=device_data, source=self)
 

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -465,6 +465,11 @@ inventory_file_path = /full/path/to/inventory/files
 ; NetBox
 ;overwrite_host_name = False
 
+; for Dell devices, use the Service Tag as the NetBox device serial number (matching what
+; dmidecode and the OS report) instead of the system serial number. The original system
+; serial number (the Dell PPID) is then stored in the 'system_serial' custom field
+;dell_serial_from_service_tag = False
+
 ; define if the name of the power supply discovered via check_redfish overwrites the power
 ; supply name in NetBox
 ;overwrite_power_supply_name = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,9 +22,16 @@ from types import SimpleNamespace
 
 import pytest
 
+from module.config.base import ConfigOptions
+from module.config.group import ConfigOptionGroup
+from module.config.option import ConfigOption
 from module.config.parser import ConfigParser
+from module.netbox.connection import NetBoxHandler
 from module.netbox.inventory import NetBoxInventory
+from module.netbox.object_classes import NBDevice, NBTag
 from module.sources import instantiate_sources
+from module.sources.check_redfish.config import CheckRedfishConfig
+from module.sources.check_redfish.import_inventory import CheckRedfish
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "vcsim"
 
@@ -194,3 +201,53 @@ def sdk(vcsim):
         yield instance.RetrieveContent()
     finally:
         connect.Disconnect(instance)
+
+
+@pytest.fixture
+def check_redfish_source(inventory):
+    """
+    Returns a function building a minimally initialized CheckRedfish source on the fresh
+    inventory, with a device to hang components off. The real add_necessary_base_objects()
+    runs, so the source tag and every custom field are registered as they are in production.
+
+    Settings start from the declared defaults of every CheckRedfishConfig option and are
+    overridden by keyword arguments, so a test states only what it cares about and an option
+    added to the config later reaches the tests with its real default.
+    """
+    def _make(**overrides: object) -> SimpleNamespace:
+        source = object.__new__(CheckRedfish)
+        source.inventory = inventory
+        source.name = "test"
+        source.source_tag = "Source: test"
+        source.settings = check_redfish_settings(**overrides)
+
+        source.add_necessary_base_objects()
+        # the primary tag is normally registered by the NetBox handler, not by the source
+        inventory.add_update_object(NBTag, data={"name": NetBoxHandler.primary_tag})
+
+        device = inventory.add_object(NBDevice, data={"name": "server01"}, source=source)
+        source.device_object = device
+
+        return SimpleNamespace(source=source, inventory=inventory, device=device)
+
+    return _make
+
+
+def check_redfish_settings(**overrides) -> ConfigOptions:
+    """
+    The settings a parsed check_redfish config produces: every declared option at its default,
+    with the given overrides applied. ConfigOptions is what ConfigBase.parse() returns, so an
+    option this source does not declare reads as None here exactly as it does in production.
+    """
+    values = {}
+    for entry in CheckRedfishConfig().options:
+        declared = entry.options if isinstance(entry, ConfigOptionGroup) else [entry]
+        for option in declared:
+            if isinstance(option, ConfigOption) and option.removed is not True:
+                values[option.key] = option.default_value
+
+    unknown = set(overrides) - set(values)
+    assert not unknown, f"not declared by CheckRedfishConfig: {sorted(unknown)}"
+
+    values.update(overrides)
+    return ConfigOptions(**values)

--- a/tests/test_check_redfish_device_serial.py
+++ b/tests/test_check_redfish_device_serial.py
@@ -1,0 +1,250 @@
+"""The Dell Service Tag can be used as the NetBox device serial instead of the system serial.
+
+Drives the real update_device() and find_device_object() against real NBDevice objects.
+"""
+
+from module.common.misc import grab
+from module.netbox.object_classes import NBDevice
+
+SYSTEM_SERIAL = "CNEXAMPLE00001"
+SERVICE_TAG = "ABC1234"
+
+
+def dell_system(system_serial=SYSTEM_SERIAL, service_tag=SERVICE_TAG, with_chassis=True):
+    """A Dell system as check_redfish reports it: system.serial is the board PPID,
+    the Service Tag is chassis.sku."""
+
+    content = {"inventory": {"system": [
+        {"id": "1", "name": "System", "manufacturer": "Dell Inc.", "model": "PowerEdge R650",
+         "serial": system_serial, "host_name": "server01",
+         "health_status": "OK", "power_state": "On"}]}}
+    if with_chassis:
+        content["inventory"]["chassis"] = [{"id": "1", "sku": service_tag}]
+    return content
+
+
+def run_update_device(source, content, dell_serial_from_service_tag):
+    source.settings.dell_serial_from_service_tag = dell_serial_from_service_tag
+    source.inventory_file_content = content
+    source.update_device()
+    return source.device_object
+
+
+def match_content(system_serial=SYSTEM_SERIAL, service_tag=SERVICE_TAG):
+    """An inventory file without meta.inventory_id, so matching falls back to the serial."""
+
+    return {"inventory": {
+        "system": [{"manufacturer": "Dell Inc.", "serial": system_serial}],
+        "chassis": [{"sku": service_tag}],
+    }}
+
+
+def test_serial_defaults_to_the_system_serial(check_redfish_source):
+    """Existing behaviour with the option off, which must not change."""
+
+    context = check_redfish_source()
+    device = run_update_device(context.source, dell_system(), dell_serial_from_service_tag=False)
+
+    assert device.data["serial"] == SYSTEM_SERIAL
+    assert grab(device, "data.custom_fields.service_tag") == SERVICE_TAG
+    assert grab(device, "data.custom_fields.system_serial") is None
+
+
+def test_option_makes_the_service_tag_the_serial(check_redfish_source):
+    context = check_redfish_source()
+    device = run_update_device(context.source, dell_system(), dell_serial_from_service_tag=True)
+
+    assert device.data["serial"] == SERVICE_TAG
+    assert grab(device, "data.custom_fields.system_serial") == SYSTEM_SERIAL
+    assert grab(device, "data.custom_fields.service_tag") == SERVICE_TAG
+
+
+def test_option_falls_back_when_no_service_tag_is_reported(check_redfish_source):
+    """No Service Tag means no swap, so the serial is not lost."""
+
+    context = check_redfish_source()
+    device = run_update_device(context.source, dell_system(with_chassis=False),
+                               dell_serial_from_service_tag=True)
+
+    assert device.data["serial"] == SYSTEM_SERIAL
+    assert grab(device, "data.custom_fields.system_serial") is None
+
+
+def test_blank_service_tag_is_not_a_service_tag(check_redfish_source):
+    context = check_redfish_source()
+    device = run_update_device(context.source, dell_system(service_tag="   "),
+                               dell_serial_from_service_tag=True)
+
+    assert grab(device, "data.custom_fields.service_tag") is None
+    assert device.data["serial"] == SYSTEM_SERIAL
+    assert grab(device, "data.custom_fields.system_serial") is None
+
+
+def test_system_serial_custom_field_is_not_overwritten_with_none(check_redfish_source):
+    """A transient missing system serial must not clear the field on a later sync."""
+
+    context = check_redfish_source()
+    device = run_update_device(context.source, dell_system(), dell_serial_from_service_tag=True)
+    assert grab(device, "data.custom_fields.system_serial") == SYSTEM_SERIAL
+
+    run_update_device(context.source, dell_system(system_serial=None), dell_serial_from_service_tag=True)
+
+    assert grab(device, "data.custom_fields.system_serial") == SYSTEM_SERIAL
+
+
+def test_device_is_matched_by_system_serial(check_redfish_source):
+    """Existing fallback matching, which must not change."""
+
+    context = check_redfish_source()
+    context.source.settings.dell_serial_from_service_tag = False
+    existing = context.inventory.add_object(
+        NBDevice, data={"name": "dell-host", "serial": SYSTEM_SERIAL}, source=context.source)
+
+    context.source.inventory_file_content = match_content()
+
+    assert context.source.find_device_object("dell-host.json") is True
+    assert context.source.device_object is existing
+
+
+def test_device_not_yet_migrated_is_matched_by_system_serial_with_the_option_on(check_redfish_source):
+    context = check_redfish_source()
+    context.source.settings.dell_serial_from_service_tag = True
+    existing = context.inventory.add_object(
+        NBDevice, data={"name": "dell-host", "serial": SYSTEM_SERIAL}, source=context.source)
+
+    context.source.inventory_file_content = match_content()
+
+    assert context.source.find_device_object("dell-host.json") is True
+    assert context.source.device_object is existing
+
+
+def test_device_persisted_with_the_service_tag_is_matched_by_it(check_redfish_source):
+    """Without the Service Tag fallback such a device is skipped and stops being updated."""
+
+    context = check_redfish_source()
+    context.source.settings.dell_serial_from_service_tag = True
+    existing = context.inventory.add_object(
+        NBDevice, data={"name": "dell-host", "serial": SERVICE_TAG}, source=context.source)
+
+    context.source.inventory_file_content = match_content()
+
+    assert context.source.find_device_object("dell-host.json") is True
+    assert context.source.device_object is existing
+
+
+def test_service_tag_matching_does_not_depend_on_the_option(check_redfish_source):
+    """Disabling the option must not strand a device already persisted with the Service Tag."""
+
+    context = check_redfish_source()
+    context.source.settings.dell_serial_from_service_tag = False
+    existing = context.inventory.add_object(
+        NBDevice, data={"name": "dell-host", "serial": SERVICE_TAG}, source=context.source)
+
+    context.source.inventory_file_content = match_content()
+
+    assert context.source.find_device_object("dell-host.json") is True
+    assert context.source.device_object is existing
+
+
+def test_padded_system_serial_still_matches(check_redfish_source):
+    """update_device() stores the serial stripped, so the lookup must strip it too."""
+
+    context = check_redfish_source()
+    existing = context.inventory.add_object(
+        NBDevice, data={"name": "dell-host", "serial": SYSTEM_SERIAL}, source=context.source)
+
+    context.source.inventory_file_content = match_content(system_serial=f"  {SYSTEM_SERIAL}  ")
+
+    assert context.source.find_device_object("dell-host.json") is True
+    assert context.source.device_object is existing
+
+
+def test_missing_serial_does_not_match_a_serial_less_device(check_redfish_source):
+    """get_by_data() matches on exact dict equality, so probing serial=None would match wrongly."""
+
+    context = check_redfish_source()
+    context.inventory.add_object(NBDevice, data={"name": "serial-less"}, source=context.source)
+
+    context.source.inventory_file_content = {"inventory": {
+        "system": [{"manufacturer": "Dell Inc."}],
+    }}
+
+    assert context.source.find_device_object("dell-host.json") is False
+
+
+def seed_device_with_nb_id(source, inventory, nb_id, name="wrong-device"):
+    device = inventory.add_object(NBDevice, data={"name": name}, source=source)
+    device.nb_id = nb_id
+    return device
+
+
+def id_content(inventory_id):
+    content = match_content()
+    content["meta"] = {"inventory_id": inventory_id}
+    return content
+
+
+def test_integer_inventory_id_is_used(check_redfish_source):
+    """The normal path, which must keep working."""
+
+    context = check_redfish_source()
+    wanted = seed_device_with_nb_id(context.source, context.inventory, 1, name="by-id")
+
+    context.source.inventory_file_content = id_content(1)
+
+    assert context.source.find_device_object("host.json") is True
+    assert context.source.device_object is wanted
+
+
+def test_digit_string_inventory_id_is_used(check_redfish_source):
+    """meta.inventory_id arrives from JSON, where it may be quoted."""
+
+    context = check_redfish_source()
+    wanted = seed_device_with_nb_id(context.source, context.inventory, 1, name="by-id")
+
+    context.source.inventory_file_content = id_content("1")
+
+    assert context.source.find_device_object("host.json") is True
+    assert context.source.device_object is wanted
+
+
+def test_boolean_inventory_id_does_not_match_device_one(check_redfish_source):
+    """int(True) is 1, so a JSON `true` would silently claim the device with id 1."""
+
+    context = check_redfish_source()
+    seed_device_with_nb_id(context.source, context.inventory, 1)
+    by_serial = context.inventory.add_object(
+        NBDevice, data={"name": "dell-host", "serial": SYSTEM_SERIAL}, source=context.source)
+
+    context.source.inventory_file_content = id_content(True)
+
+    assert context.source.find_device_object("host.json") is True
+    assert context.source.device_object is by_serial
+
+
+def test_float_inventory_id_does_not_match_the_truncated_device(check_redfish_source):
+    """int(1.9) is 1, so a JSON float would silently claim the device with id 1."""
+
+    context = check_redfish_source()
+    seed_device_with_nb_id(context.source, context.inventory, 1)
+    by_serial = context.inventory.add_object(
+        NBDevice, data={"name": "dell-host", "serial": SYSTEM_SERIAL}, source=context.source)
+
+    context.source.inventory_file_content = id_content(1.9)
+
+    assert context.source.find_device_object("host.json") is True
+    assert context.source.device_object is by_serial
+
+
+def test_non_positive_inventory_id_is_rejected(check_redfish_source):
+    """NetBox ids start at 1, so zero and negatives are not usable ids."""
+
+    context = check_redfish_source()
+    seed_device_with_nb_id(context.source, context.inventory, 0)
+    by_serial = context.inventory.add_object(
+        NBDevice, data={"name": "dell-host", "serial": SYSTEM_SERIAL}, source=context.source)
+
+    context.source.inventory_file_content = id_content(0)
+
+    assert context.source.find_device_object("host.json") is True
+    assert context.source.device_object is by_serial

--- a/tests/test_check_redfish_inventory_items.py
+++ b/tests/test_check_redfish_inventory_items.py
@@ -4,35 +4,7 @@ Drives the real CheckRedfish methods against the real NetBoxInventory and NetBox
 classes. Only the NetBox REST API itself is out of scope.
 """
 
-import types
-
-from module.netbox.inventory import NetBoxInventory
-from module.netbox.object_classes import NBDevice, NBInventoryItem
-from module.sources.check_redfish.import_inventory import CheckRedfish
-
-
-def make_source():
-    """Build a CheckRedfish source on a fresh inventory, with the real base objects registered."""
-
-    inventory = NetBoxInventory()
-    # reset the singleton state so each test starts from an empty inventory
-    inventory.init()
-    inventory.source_list = list()
-    inventory.netbox_api_version = "4.3.0"
-
-    source = object.__new__(CheckRedfish)
-    source.inventory = inventory
-    source.name = "test"
-    source.source_tag = "Source: test"
-    source.settings = types.SimpleNamespace()
-
-    source.add_necessary_base_objects()
-
-    device = inventory.add_object(NBDevice, data={"name": "server01"}, source=source)
-    source.device_object = device
-
-    return source, inventory, device
-
+from module.netbox.object_classes import NBInventoryItem
 
 # a Dell `location` as check_redfish can hand it back: a nested Oem object, not a string
 DELL_LOCATION = {
@@ -53,15 +25,15 @@ def enclosure(name, location, serial="ENC-AAA"):
          "operation_status": "Enabled"}]}}
 
 
-def test_structured_location_is_not_stringified_into_the_item_name():
+def test_structured_location_is_not_stringified_into_the_item_name(check_redfish_source):
     """A structured location must not reach the name as its Python repr."""
 
-    source, inventory, _ = make_source()
+    context = check_redfish_source()
 
-    source.inventory_file_content = enclosure("BP_PSV 0:1", DELL_LOCATION)
-    source.update_storage_enclosure()
+    context.source.inventory_file_content = enclosure("BP_PSV 0:1", DELL_LOCATION)
+    context.source.update_storage_enclosure()
 
-    items = inventory.get_all_items(NBInventoryItem)
+    items = context.inventory.get_all_items(NBInventoryItem)
     assert len(items) == 1
 
     name = items[0].data["name"]
@@ -72,29 +44,29 @@ def test_structured_location_is_not_stringified_into_the_item_name():
     assert name == "BP_PSV 0:1"
 
 
-def test_plain_string_location_is_kept_in_the_item_name():
+def test_plain_string_location_is_kept_in_the_item_name(check_redfish_source):
     """A location that really is a string is still used."""
 
-    source, inventory, _ = make_source()
+    context = check_redfish_source()
 
-    source.inventory_file_content = enclosure("BP_PSV 0:1", "Slot 3")
-    source.update_storage_enclosure()
+    context.source.inventory_file_content = enclosure("BP_PSV 0:1", "Slot 3")
+    context.source.update_storage_enclosure()
 
-    items = inventory.get_all_items(NBInventoryItem)
+    items = context.inventory.get_all_items(NBInventoryItem)
     assert len(items) == 1
     assert items[0].data["name"] == "BP_PSV 0:1 Slot 3"
 
 
-def test_two_enclosures_with_structured_locations_stay_distinct():
+def test_two_enclosures_with_structured_locations_stay_distinct(check_redfish_source):
     """Dropping the unusable location must not merge two enclosures onto one name."""
 
-    source, inventory, _ = make_source()
+    context = check_redfish_source()
 
-    source.inventory_file_content = {"inventory": {"storage_enclosure": [
+    context.source.inventory_file_content = {"inventory": {"storage_enclosure": [
         enclosure("BP_PSV 0:1", DELL_LOCATION, "ENC-AAA")["inventory"]["storage_enclosure"][0],
         enclosure("BP_PSV 0:2", DELL_LOCATION, "ENC-BBB")["inventory"]["storage_enclosure"][0],
     ]}}
-    source.update_storage_enclosure()
+    context.source.update_storage_enclosure()
 
-    names = sorted(item.data["name"] for item in inventory.get_all_items(NBInventoryItem))
+    names = sorted(item.data["name"] for item in context.inventory.get_all_items(NBInventoryItem))
     assert names == ["BP_PSV 0:1", "BP_PSV 0:2"]

--- a/tests/test_check_redfish_orphan_tagging.py
+++ b/tests/test_check_redfish_orphan_tagging.py
@@ -7,34 +7,7 @@ NetBoxInventory. Only the NetBox REST API itself is out of scope.
 import types
 
 from module.netbox.connection import NetBoxHandler
-from module.netbox.inventory import NetBoxInventory
-from module.netbox.object_classes import NBDevice, NBInventoryItem, NBTag
-from module.sources.check_redfish.import_inventory import CheckRedfish
-
-
-def make_source():
-    """Build a CheckRedfish source on a fresh inventory, with the real base objects registered."""
-
-    inventory = NetBoxInventory()
-    # reset the singleton state so each test starts from an empty inventory
-    inventory.init()
-    inventory.source_list = list()
-    inventory.netbox_api_version = "4.3.0"
-
-    source = object.__new__(CheckRedfish)
-    source.inventory = inventory
-    source.name = "test"
-    source.source_tag = "Source: test"
-    source.settings = types.SimpleNamespace()
-
-    source.add_necessary_base_objects()
-    # the primary tag is normally registered by the NetBox handler, not by the source
-    inventory.add_update_object(NBTag, data={"name": NetBoxHandler.primary_tag})
-
-    device = inventory.add_object(NBDevice, data={"name": "server01"}, source=source)
-    source.device_object = device
-
-    return source, inventory, device
+from module.netbox.object_classes import NBInventoryItem
 
 
 def make_netbox_handler():
@@ -59,63 +32,63 @@ def existing_item(source, device, name, inventory_type, health="OK"):
     return item
 
 
-def test_components_are_marked_absent_when_the_scan_reports_none_of_their_type():
+def test_components_are_marked_absent_when_the_scan_reports_none_of_their_type(check_redfish_source):
     """A scan reporting no fan says the fans are gone, so they must be marked absent."""
 
-    source, inventory, device = make_source()
-    source.inventory.source_list.append(source)
-    fan = existing_item(source, device, "Fan 1 (ID: 1)", "Fan")
+    context = check_redfish_source()
+    context.inventory.source_list.append(context.source)
+    fan = existing_item(context.source, context.device, "Fan 1 (ID: 1)", "Fan")
 
-    source.inventory_file_content = {"inventory": {"fan": []}}
-    source.update_fan()
+    context.source.inventory_file_content = {"inventory": {"fan": []}}
+    context.source.update_fan()
 
     assert fan.data["custom_fields"]["health"] == "Absent"
-    assert fan.source is source, "the run must claim the item, or it is tagged orphaned"
+    assert fan.source is context.source, "the run must claim the item, or it is tagged orphaned"
 
-    inventory.tag_all_the_things(make_netbox_handler())
+    context.inventory.tag_all_the_things(make_netbox_handler())
     assert NetBoxHandler.orphaned_tag not in fan.get_tags()
 
 
-def test_components_already_absent_are_claimed_again_on_every_run():
+def test_components_already_absent_are_claimed_again_on_every_run(check_redfish_source):
     """An item already at absent must still be claimed, or it is tagged orphaned."""
 
-    source, inventory, device = make_source()
-    source.inventory.source_list.append(source)
-    fan = existing_item(source, device, "Fan 1 (ID: 1)", "Fan", health="Absent")
+    context = check_redfish_source()
+    context.inventory.source_list.append(context.source)
+    fan = existing_item(context.source, context.device, "Fan 1 (ID: 1)", "Fan", health="Absent")
 
-    source.inventory_file_content = {"inventory": {"fan": []}}
-    source.update_fan()
+    context.source.inventory_file_content = {"inventory": {"fan": []}}
+    context.source.update_fan()
 
-    assert fan.source is source, "an already absent item must still be claimed by the run"
+    assert fan.source is context.source, "an already absent item must still be claimed by the run"
 
-    inventory.tag_all_the_things(make_netbox_handler())
+    context.inventory.tag_all_the_things(make_netbox_handler())
     assert NetBoxHandler.orphaned_tag not in fan.get_tags()
 
 
-def test_components_of_another_type_are_left_alone():
+def test_components_of_another_type_are_left_alone(check_redfish_source):
     """An empty fan batch says nothing about the CPUs, which must not be marked absent."""
 
-    source, inventory, device = make_source()
-    source.inventory.source_list.append(source)
-    cpu = existing_item(source, device, "Socket 1", "CPU")
+    context = check_redfish_source()
+    context.inventory.source_list.append(context.source)
+    cpu = existing_item(context.source, context.device, "Socket 1", "CPU")
 
-    source.inventory_file_content = {"inventory": {"fan": []}}
-    source.update_fan()
+    context.source.inventory_file_content = {"inventory": {"fan": []}}
+    context.source.update_fan()
 
     assert cpu.data["custom_fields"]["health"] == "OK"
 
 
-def test_reported_components_are_still_updated_normally():
+def test_reported_components_are_still_updated_normally(check_redfish_source):
     """The empty batch handling must not disturb the ordinary path."""
 
-    source, inventory, device = make_source()
+    context = check_redfish_source()
 
-    source.inventory_file_content = {"inventory": {"fan": [
+    context.source.inventory_file_content = {"inventory": {"fan": [
         {"name": "Fan 1", "id": "1", "health_status": "OK", "operation_status": "Enabled",
          "physical_context": "CPU", "reading": 4200, "reading_unit": "RPM"}]}}
-    source.update_fan()
+    context.source.update_fan()
 
-    items = inventory.get_all_items(NBInventoryItem)
+    items = context.inventory.get_all_items(NBInventoryItem)
     assert len(items) == 1
     assert items[0].data["custom_fields"]["health"] == "OK"
     assert items[0].data["custom_fields"]["inventory_type"] == "Fan"


### PR DESCRIPTION
## Problem

Dell iDRAC reports the system board **PPID** (e.g. `CNEXAMPLE00001`) as `ComputerSystem.SerialNumber`, so the device serial written to NetBox is the PPID.

The **Service Tag** (e.g. `ABC1234`) is what `dmidecode -s system-serial-number` reports, what the OS and most fleet tooling use to identify the box, and what the iDRAC host name is built from. It was only stored in the `service_tag` custom field, so NetBox disagreed with every other system about the machine's serial.

## Fix

New option `dell_serial_from_service_tag`, bool, default `false`, so behaviour is unchanged unless it is set.

When it is set, and the device is a Dell reporting a chassis SKU, the device serial becomes the Service Tag and the PPID moves to a new `system_serial` custom field. Without a usable SKU the serial stays the system serial, so nothing is lost.

## Supporting changes

**Device matching is extracted from `apply()` into `find_device_object()`** and now also matches by Service Tag. The order is `meta.inventory_id`, then system serial, then Service Tag.

The Service Tag lookup is deliberately **not** gated on the option. A device persisted with the Service Tag as its serial would otherwise be stranded and silently skipped (`continue`) if the option were later disabled. `get_service_tag()` self-gates on the vendor and centralises the lookup, so matching and updating cannot disagree about the value.

Also:
- The serial lookup did not normalise the value the way `update_device()` stores it (via `get_string_or_none`), so a padded serial never matched the stored one.
- A missing serial probed `get_by_data(NBDevice, {"serial": None})`. That compares dicts exactly, so it matched a device which has no serial at all.

An absent `meta.inventory_id` is the normal case when devices are matched by serial, so it no longer logs a misleading "must be an integer" warning for it, and no longer probes `get_by_id()` with an invalid id.

## Generated file

`settings-example.ini` is regenerated with `netbox-sync.py -g` 
