### PR TITLE
fix: parse reevaluated VMs once and reuse their MAC objects

### DIFF
--- a/module/sources/common/source_base.py
+++ b/module/sources/common/source_base.py
@@ -407,8 +407,9 @@ class SourceBase:
             # if a new interface or not matching assigned MAC address, try to find an existing unassigned mac address
             if primary_mac_address_object is None:
                 for mac_address_object in self.inventory.get_all_items(NBMACAddress):
+                    # an object already assigned to this very interface is the one we want, not a duplicate
                     if (grab(mac_address_object, "data.mac_address") == interface_mac_address and
-                            grab(mac_address_object, "data.assigned_object_id") is None):
+                            grab(mac_address_object, "data.assigned_object_id") in (None, interface_object)):
                         primary_mac_address_object = mac_address_object
                         break
 

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -2233,7 +2233,8 @@ class VMWareHandler(SourceBase):
         # get VM UUID
         vm_uuid = grab(obj, "config.instanceUuid")
 
-        if vm_uuid is None or vm_uuid in self.processed_vm_uuid and obj not in self.objects_to_reevaluate:
+        if (vm_uuid is None or vm_uuid in self.processed_vm_uuid) and \
+                not (self.parsing_objects_to_reevaluate is True and obj in self.objects_to_reevaluate):
             return
 
         log.debug(f"Parsing vCenter VM: {name}")

--- a/tests/test_vmware_reevaluation_mac_duplicates.py
+++ b/tests/test_vmware_reevaluation_mac_duplicates.py
@@ -1,0 +1,15 @@
+"""
+Parsing a VM more than once in a run (it is queued for reevaluation) must not
+create a second NBMACAddress for the same interface and address (issue #542).
+On the 6.7 capture one VM is queued and, on development, its interfaces end up
+with 18 duplicate MAC objects.
+"""
+from module.netbox.object_classes import NBMACAddress
+
+
+def test_no_duplicate_mac_objects_after_a_sync(vmware_sync):
+    inventory = vmware_sync.inventory
+    macs = list(inventory.get_all_items(NBMACAddress))
+    pairs = {(id(mac.data.get("assigned_object_id")), str(mac.data.get("mac_address")).lower()) for mac in macs}
+    duplicates = len(macs) - len(pairs)
+    assert duplicates == 0, f"{duplicates} MAC address objects duplicate an (interface, address) pair"


### PR DESCRIPTION
Fixes #542

Two logic errors combine into duplicate `NBMACAddress` objects on the first run:

1. In `add_virtual_machine()` the guard lets a VM queued for reevaluation through during the view walks, not only in the reevaluation pass. The "offline virtual machine" view walks the same objects again, so a queued VM was parsed a second time there and a third time in the reevaluation pass. The exception now applies only while `parsing_objects_to_reevaluate` is set. Bracketing the condition alone changes nothing (measured 18 -> 18 duplicates on the 6.7 capture).
2. In `add_update_interface()` the MAC reuse for an interface created in the same run only considers unassigned objects, so a second parse creates a second object for the same interface and address. An object already assigned to that very interface is now reused.

Measured on the 6.7 capture (`vchvr`): 82 objects / 64 pairs on `development`; guard fix alone 73; reuse fix alone 64; both 64. `tests/test_vmware_reevaluation_mac_duplicates.py` fails on `development` with 18 duplicates and passes here. Full suite green.