### PR TITLE
fix: skip_host_nics must skip only the physical interfaces, not the host

### DIFF
--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -1896,9 +1896,6 @@ class VMWareHandler(SourceBase):
         if len(host_custom_fields) > 0:
             host_data["custom_fields"] = host_custom_fields
 
-        if self.settings.skip_host_nics is True:
-            return
-
         # iterate over hosts virtual switches, needed to enrich data on physical interfaces
         self.network_data["vswitch"][name] = dict()
         for vswitch in grab(obj, "config.network.vswitch", fallback=list()):
@@ -1968,7 +1965,11 @@ class VMWareHandler(SourceBase):
         except Exception:
             pass
 
-        for pnic in grab(obj, "config.network.pnic", fallback=list()):
+        pnic_list = grab(obj, "config.network.pnic", fallback=list())
+        if self.settings.skip_host_nics is True:
+            log.debug(f"Skipping physical interfaces of host '{name}' (skip_host_nics)")
+            pnic_list = list()
+        for pnic in pnic_list:
 
             pnic_name = grab(pnic, "device")
             pnic_key = grab(pnic, "key")

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -316,6 +316,11 @@ password = super-secret
 ; Do not sync template VMs
 ;skip_vm_templates = True
 
+; Do not sync the physical interfaces (pNICs) of ESXi hosts. The host itself and its
+; VMkernel interfaces are still synced. Existing physical interfaces are no longer
+; updated by this source and are treated as unreported (see the prune settings)
+;skip_host_nics = False
+
 ; Skip virtual machines which are reported as offline.
 ; ATTENTION: this option will keep purging stopped VMs if activated!
 ;skip_offline_vms = False

--- a/settings-example.ini
+++ b/settings-example.ini
@@ -317,8 +317,9 @@ password = super-secret
 ;skip_vm_templates = True
 
 ; Do not sync the physical interfaces (pNICs) of ESXi hosts. The host itself and its
-; VMkernel interfaces are still synced. Existing physical interfaces are no longer
-; updated by this source and are treated as unreported (see the prune settings)
+; VMkernel interfaces are still synced. Physical interfaces which were synced before
+; enabling this option are no longer updated: either remove the source tag from them
+; to keep them, or let the prune run remove them as orphaned objects
 ;skip_host_nics = False
 
 ; Skip virtual machines which are reported as offline.

--- a/tests/test_vmware_skip_host_nics.py
+++ b/tests/test_vmware_skip_host_nics.py
@@ -1,0 +1,24 @@
+"""
+`skip_host_nics` must skip only the physical interfaces of an ESXi host. The host
+itself, its VMkernel interfaces and the VMs on it are still synced (PR #442 review).
+"""
+from module.netbox.object_classes import NBDevice, NBInterface, NBVM
+from module.sources import instantiate_sources
+
+
+def test_skip_host_nics_keeps_hosts_and_vmkernel_interfaces(vcsim, inventory, load_config, vmware_settings):
+    load_config(vmware_settings + "\nskip_host_nics = True\n")
+    sources = instantiate_sources()
+    assert sources and sources[0].init_successful
+    inventory.resolve_relations()
+    sources[0].apply()
+
+    hosts = list(inventory.get_all_items(NBDevice))
+    assert hosts, "hosts must still be synced with skip_host_nics enabled"
+    assert list(inventory.get_all_items(NBVM)), "VMs must still be synced"
+
+    interfaces = list(inventory.get_all_items(NBInterface))
+    physical = [i for i in interfaces if "virtual" not in str(i.data.get("type", "virtual"))]
+    vmkernel = [i for i in interfaces if "virtual" in str(i.data.get("type", "virtual"))]
+    assert physical == [], f"physical interfaces were synced: {[i.get_display_name() for i in physical]}"
+    assert vmkernel, "VMkernel interfaces must still be synced"


### PR DESCRIPTION
Follow-up to #442, raised in its review.

The early `return` sat in `add_host()` before the host is added to the inventory, so with `skip_host_nics = True` the whole host was dropped instead of just its physical interfaces. Verified with the vcsim suite: on current `development` the option leaves zero hosts; with this change the hosts, their VMkernel interfaces and the VMs are synced and only the pNICs are skipped. The vswitch/port-group data is still collected because the VM interface parsing relies on it.

Also adds the option to `settings-example.ini`, which #442 did not, and documents that existing physical interfaces are no longer updated by the source once the option is on.

Test: `tests/test_vmware_skip_host_nics.py` fails on `development` (no hosts) and passes here. Full suite green.