### PR TITLE
fix: keep an existing device type when the host reports a placeholder model

### DIFF
--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -90,6 +90,11 @@ class VMWareHandler(SourceBase):
 
     site_name = None
 
+    # values a BIOS reports when the vendor left the SMBIOS fields unset, plus the dummy vendor/model
+    # used for hosts where nothing better is known. None of these identify real hardware.
+    unknown_hardware_identifiers = ["Default string", "NA", "N/A", "None", "Null", "oem", "o.e.m",
+                                    "to be filled by o.e.m.", "Unknown", "Generic Vendor", "Generic Model"]
+
     def __init__(self, name=None):
 
         if name is None:
@@ -446,6 +451,27 @@ class VMWareHandler(SourceBase):
             return False
 
         return True
+
+    @staticmethod
+    def hardware_identifier_is_unknown(value):
+        """
+        checks if a hardware identifier (vendor, model, asset tag) reported for a host
+        is a placeholder rather than a real value.
+
+        Parameters
+        ----------
+        value: str
+            identifier to check
+
+        Returns
+        -------
+        bool: True if value is unset or one of the known placeholders, otherwise False
+        """
+
+        if value is None:
+            return True
+
+        return value.lower() in [x.lower() for x in VMWareHandler.unknown_hardware_identifiers]
 
     def get_site_name(self, object_type, object_name, cluster_name=""):
         """
@@ -1225,6 +1251,12 @@ class VMWareHandler(SourceBase):
                     object_data.get("platform") is not None:
                 del object_data["platform"]
 
+            # a device type made up from a BIOS placeholder carries no information. Keep the one
+            # already set in NetBox instead of replacing it on every run (issue #460)
+            if object_type == NBDevice and object_data.get("device_type") is not None and \
+                    self.hardware_identifier_is_unknown(grab(object_data, "device_type.model")):
+                del object_data["device_type"]
+
             device_vm_object.update(data=object_data, source=self)
 
         # add object to cache
@@ -1814,11 +1846,11 @@ class VMWareHandler(SourceBase):
         platform = f"{product_name} {product_version}"
         platform = self.get_object_relation(platform, "host_platform_relation", fallback=platform)
 
-        # if the device vendor/model cannot be retrieved (due to problem on the host),
-        # set a dummy value so the host still gets synced
-        if manufacturer is None:
+        # if the device vendor/model cannot be retrieved (due to problem on the host) or the BIOS
+        # only reports a placeholder, set a dummy value so the host still gets synced
+        if self.hardware_identifier_is_unknown(manufacturer):
             manufacturer = "Generic Vendor"
-        if model is None:
+        if self.hardware_identifier_is_unknown(model):
             model = "Generic Model"
 
         # get status
@@ -1848,12 +1880,9 @@ class VMWareHandler(SourceBase):
 
         if self.settings.collect_hardware_asset_tag is True and "AssetTag" in identifier_dict.keys():
 
-            banned_tags = ["Default string", "NA", "N/A", "None", "Null", "oem", "o.e.m",
-                           "to be filled by o.e.m.", "Unknown"]
-
             this_asset_tag = identifier_dict.get("AssetTag")
 
-            if this_asset_tag.lower() not in [x.lower() for x in banned_tags]:
+            if not self.hardware_identifier_is_unknown(this_asset_tag):
                 asset_tag = this_asset_tag
 
         # get host_tenant_relation

--- a/tests/test_vmware_host_device_type.py
+++ b/tests/test_vmware_host_device_type.py
@@ -1,0 +1,113 @@
+"""
+Regression tests for issue #460 (device type of ESXi hosts overwritten).
+
+Some BIOSes report placeholders such as "Default string" instead of the real
+hardware model. netbox-sync turned that into a device type and re-assigned it on
+every run, replacing a device type the user had set by hand in NetBox. These tests
+drive the real add_device_vm_to_inventory path of the VMware handler against the
+in-memory NetBoxInventory (no vCenter needed).
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from module.netbox.object_classes import NBSite, NBManufacturer, NBDeviceType, NBDevice
+from module.sources.vmware.connection import VMWareHandler
+
+
+def _make_source(inventory):
+    # build the handler without its network-bound __init__
+    src = object.__new__(VMWareHandler)
+    src.inventory = inventory
+    src.name = "test"
+    src.source_tag = "Source: test"
+    src.object_cache = dict()
+    src.settings = SimpleNamespace(
+        match_host_by_serial=True,
+        match_vm_by_serial=True,
+        match_vm_by_mac_address=True,
+        match_vm_by_ip_address=True,
+        overwrite_device_platform=False,
+        overwrite_vm_platform=False,
+        host_role_relation=[],
+        host_interface_exclude_filter=None,
+        vm_interface_exclude_filter=None,
+        set_primary_ip="when-undefined",
+        vm_exclude_disk_sync=None,
+        vm_exclude_disk_sync_by_tag=None,
+    )
+    return src
+
+
+def _existing_host(inventory, model="PowerEdge R740", manufacturer="Dell"):
+    # a device as it would be read from NetBox, with a device type set by hand
+    site = inventory.add_object(NBSite, data={"name": "site1"}, read_from_netbox=True)
+    vendor = inventory.add_object(NBManufacturer, data={"name": manufacturer}, read_from_netbox=True)
+    device_type = inventory.add_object(NBDeviceType, data={"model": model, "manufacturer": vendor},
+                                       read_from_netbox=True)
+    return inventory.add_object(NBDevice, data={
+        "name": "esxi01", "site": site, "device_type": device_type, "serial": "SN123", "status": "active",
+    }, read_from_netbox=True)
+
+
+def _sync_host(src, model, manufacturer="Generic Vendor", name="esxi01", serial="SN123"):
+    # the host data add_host() hands over for an ESXi host reporting the given model
+    host_data = {
+        "name": name,
+        "device_type": {"model": model, "manufacturer": {"name": manufacturer}},
+        "site": {"name": "site1"},
+        "status": "active",
+        "serial": serial,
+    }
+    src.add_device_vm_to_inventory(NBDevice, object_data=host_data, pnic_data={}, vnic_data={}, nic_ips={})
+    return src.inventory.get_by_data(NBDevice, data={"name": name, "site": {"name": "site1"}})
+
+
+def _model_of(device):
+    return device.data.get("device_type").data.get("model")
+
+
+@pytest.mark.parametrize("junk_model", ["Default string", "Generic Model"])
+def test_existing_device_type_survives_unknown_model(inventory, junk_model):
+    # a BIOS placeholder, or the generic name add_host() substitutes for it, must not
+    # replace the device type set in NetBox (issue #460)
+    device = _existing_host(inventory)
+
+    synced = _sync_host(_make_source(inventory), model=junk_model)
+
+    assert synced is device
+    assert _model_of(device) == "PowerEdge R740", "device type was replaced by the unknown model"
+    assert "device_type" not in device.updated_items
+
+
+def test_existing_device_type_follows_real_model(inventory):
+    # a real model reported by vCenter still updates the device type
+    device = _existing_host(inventory)
+
+    synced = _sync_host(_make_source(inventory), model="PowerEdge R750", manufacturer="Dell")
+
+    assert synced is device
+    assert _model_of(device) == "PowerEdge R750"
+
+
+def test_new_device_gets_placeholder_device_type(inventory):
+    # NetBox requires a device type, so a new host with an unknown model is still
+    # created with the generic placeholder
+    inventory.add_object(NBSite, data={"name": "site1"}, read_from_netbox=True)
+
+    device = _sync_host(_make_source(inventory), model="Generic Model", name="esxi02", serial="SN456")
+
+    assert device is not None and device.is_new
+    assert _model_of(device) == "Generic Model"
+    assert device.data.get("device_type").data.get("manufacturer").data.get("name") == "Generic Vendor"
+
+
+@pytest.mark.parametrize("value", ["Default string", "N/A", "To Be Filled By O.E.M.", "Unknown", "Generic Model", None])
+def test_unknown_hardware_identifiers(value):
+    # the same list of BIOS placeholders is used for asset tag, vendor and model
+    assert VMWareHandler.hardware_identifier_is_unknown(value) is True
+
+
+@pytest.mark.parametrize("value", ["PowerEdge R740", "Dell Inc."])
+def test_real_hardware_identifiers(value):
+    assert VMWareHandler.hardware_identifier_is_unknown(value) is False


### PR DESCRIPTION
Fixes #460

vCenter reports the BIOS model string as-is, and on some hosts that is a placeholder such as `Default string`. `add_host()` turned it into the device type name on every run, replacing a device type the user had set by hand. The placeholder list already used for asset tags is now applied to the model and manufacturer as well, and `add_device_vm_to_inventory()` leaves the device type of an existing device untouched when the reported model is unknown or the `Generic Model` placeholder. A new device is still created with the placeholders, since NetBox requires a device type.

Tests: `tests/test_vmware_host_device_type.py` drives the real update path in memory; on `development` the device type is replaced (10 of 12 cases fail), with the fix it is kept and a real model still updates. Full suite: 94 passed.