### PR TITLE
fix: validate permitted_subnets loudly and accept a YAML list

### DIFF
--- a/module/config/parser.py
+++ b/module/config/parser.py
@@ -162,6 +162,11 @@ class ConfigParser:
 
                 for source_name, source_data in section_data.items():
 
+                    if not isinstance(source_data, dict):
+                        self._add_error(f"Parsed config data from file '{config_file}' for "
+                                        f"'{section}/{source_name}' is not a dictionary")
+                        continue
+
                     current_data = grab(self.content, f"{section}|{source_name}", separator="|")
 
                     if current_data is None:

--- a/module/sources/common/permitted_subnets.py
+++ b/module/sources/common/permitted_subnets.py
@@ -30,8 +30,15 @@ class PermittedSubnets:
             log.info(f"Config option 'permitted_subnets' is undefined. No IP addresses will be populated to NetBox!")
             return
 
+        # a yaml config may define the subnets as a list instead of a comma separated string
+        if isinstance(config_string, list):
+            config_string = ", ".join(str(x) for x in config_string)
+
         if not isinstance(config_string, str):
-            raise ValueError("permitted subnets need to be of type string")
+            log.error(f"permitted subnets need to be a comma separated string or a list, "
+                      f"got {type(config_string).__name__}: {config_string}")
+            self._validation_failed = True
+            return
 
         subnet_list = [x.strip() for x in config_string.split(",") if x.strip() != ""]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,11 +126,12 @@ def inventory():
 @pytest.fixture
 def load_config(tmp_path):
     """
-    Returns a function that feeds a settings.ini text to netbox-sync's ConfigParser
-    singleton, replacing whatever a previous test loaded.
+    Returns a function that feeds a config file text to netbox-sync's ConfigParser
+    singleton, replacing whatever a previous test loaded. The file name decides the
+    format, settings.ini by default.
     """
-    def _load(text: str) -> ConfigParser:
-        config_file = tmp_path / "settings.ini"
+    def _load(text: str, filename: str = "settings.ini") -> ConfigParser:
+        config_file = tmp_path / filename
         config_file.write_text(text)
         parser = ConfigParser()
         parser.file_list.clear()

--- a/tests/test_permitted_subnets.py
+++ b/tests/test_permitted_subnets.py
@@ -1,0 +1,68 @@
+"""
+permitted_subnets through the real config path (issue #482):
+ConfigParser -> VMWareConfig.parse() -> PermittedSubnets -> .permitted()
+
+A YAML config may express the option as a list, which used to raise a bare
+ValueError out of config parsing. Any other unsupported type, a malformed entry
+and the option placed at the wrong nesting level have to fail config validation
+with a message naming the offending value, never silently drop every IP.
+"""
+import logging
+
+import pytest
+
+from module.sources.vmware.config import VMWareConfig
+
+IP = "172.26.34.15/24"
+
+NETBOX = """
+netbox:
+  host_fqdn: netbox.example.com
+  api_token: xyz
+"""
+SOURCE = """
+source:
+  vc:
+    type: vmware
+    host_fqdn: vcenter.example.com
+    username: u
+    password: p
+"""
+
+
+def _parse_vmware(load_config, option_lines: str):
+    load_config(NETBOX + SOURCE + option_lines, filename="settings.yaml")
+    handler = VMWareConfig()
+    handler.source_name = "vc"
+    return handler.parse(do_log=False)
+
+
+@pytest.mark.parametrize("value", [
+    "172.16.0.0/12, 10.0.0.0/8, 192.168.0.0/16",
+    "[172.16.0.0/12, 10.0.0.0/8, 192.168.0.0/16]",
+    "\n      - 172.16.0.0/12\n      - 10.0.0.0/8\n      - 192.168.0.0/16",
+], ids=["comma-string", "flow-list", "block-list"])
+def test_yaml_string_and_list_forms_permit_the_same_subnets(load_config, value):
+    settings = _parse_vmware(load_config, f"    permitted_subnets: {value}\n")
+    assert settings.permitted_subnets.permitted(IP) is True
+    assert settings.permitted_subnets.permitted("8.8.8.8/32") is False
+
+
+def test_unsupported_value_type_fails_validation(load_config, caplog):
+    caplog.set_level(logging.ERROR, logger="NetBox-Sync")
+    with pytest.raises(SystemExit):
+        _parse_vmware(load_config, "    permitted_subnets:\n      first: 10.0.0.0/8\n")
+    errors = [record.getMessage() for record in caplog.records if record.levelno == logging.ERROR]
+    assert any("dict" in message for message in errors), errors
+
+
+def test_malformed_entry_fails_validation_naming_the_entry(load_config, caplog):
+    caplog.set_level(logging.ERROR, logger="NetBox-Sync")
+    with pytest.raises(SystemExit):
+        _parse_vmware(load_config, "    permitted_subnets: 172.16.0.0/12, 10.0.0.0/8x\n")
+    assert any("10.0.0.0/8x" in record.getMessage() for record in caplog.records), caplog.text
+
+
+def test_option_next_to_the_source_name_is_a_config_error(load_config):
+    parser = load_config(NETBOX + SOURCE + "  permitted_subnets: 10.0.0.0/8\n", filename="settings.yaml")
+    assert any("permitted_subnets" in error for error in parser.config_errors), parser.config_errors


### PR DESCRIPTION
Follow-up to #482.

Tracing the report through the real config path showed that the string form parses identically from INI and YAML, on v1.8.0 and `development`, and permits the reported address. The symptom in the report (every IP skipped with only a per-IP DEBUG line) appears when the option never reaches the source: placed under `netbox:`/`common:`, a typo in the key, a `sources:` block next to `source:`, the option under another source block, or an empty `NBS_SOURCE_*` override. Two nearby gaps did produce bad failure modes and are fixed here:

- a YAML list (`- 172.16.0.0/12`) raised a bare `ValueError` out of config parsing; it is now accepted and joined, and any other unsupported type fails validation with a message naming the type and value;
- an option placed next to the source name (wrong indentation) crashed later with an `AttributeError` in `instantiate_sources()`; it is now a config error in the style of the neighbouring checks.

Tests: `tests/test_permitted_subnets.py` runs ConfigParser -> VMWareConfig -> PermittedSubnets on YAML input; 4 of 6 cases fail on `development`, all pass here. Full suite: 88 passed.