### PR TITLE
fix: scope a cluster with the site object so NetBox accepts it

### DIFF
--- a/module/netbox/object_classes.py
+++ b/module/netbox/object_classes.py
@@ -1904,7 +1904,7 @@ class NBCluster(NetBoxObject):
             "group": NBClusterGroup,
             "scope_type": self.mapping.scopes_object_types(self.scopes),
             # supports scoped clusters
-            "scope_id": NetBoxObject,
+            "scope_id": self.scopes,
             # supports pre4.2.0 clusters with site
             "site": NBSite,
             "tags": NBTagList
@@ -1917,6 +1917,9 @@ class NBCluster(NetBoxObject):
 
     def resolve_relations(self):
         log.debug2(f"Resolving relations for {self.name} '{self.get_display_name()}'")
+        # NetBox reports the scope as an id, turn it back into the object it points to,
+        # otherwise every run sees a change from the id to the object and updates the cluster
+        self.resolve_scoped_relations("scope_id", "scope_type")
         super().resolve_relations()
 
 

--- a/module/sources/vmware/connection.py
+++ b/module/sources/vmware/connection.py
@@ -1628,8 +1628,11 @@ class VMWareHandler(SourceBase):
                 log.debug(f"Cluster '{full_cluster_name}' (or {name}) has scope type '{scope_type}' "
                           f"and scope id '{scope_id}'.")
             elif site_name is not None:
+                # NetBox wants the id of the scoped object, so the site has to be a real
+                # object here. A plain dict is sent as is and rejected with
+                # "scope_id: A valid integer is required."
                 data["scope_type"] = "dcim.site"
-                data["scope_id"] = {"name": site_name}
+                data["scope_id"] = self.inventory.add_update_object(NBSite, data={"name": site_name})
             else:
                 log.debug(f"Cluster '{full_cluster_name}' has no scope type or scope id.")
         else:

--- a/tests/test_cluster_scope.py
+++ b/tests/test_cluster_scope.py
@@ -1,0 +1,51 @@
+"""
+A cluster scoped to a site has to carry the site object, not a name (NetBox wants the
+id of the scoped object), and a scope read back from NetBox as an id has to resolve to
+that object again, otherwise every run reports a change.
+"""
+from module.netbox.object_classes import NBCluster, NBClusterType, NBSite
+
+
+def test_cluster_scope_is_resolved_from_an_id(inventory):
+    site = inventory.add_object(NBSite, data={"name": "site1"}, read_from_netbox=True)
+    site.nb_id = 7
+    ctype = inventory.add_object(NBClusterType, data={"name": "vmware"}, read_from_netbox=True)
+
+    # this is the shape NetBox hands back for a scoped cluster
+    cluster = inventory.add_object(NBCluster, data={
+        "name": "c1", "type": ctype, "scope_type": "dcim.site", "scope_id": 7,
+    }, read_from_netbox=True)
+    cluster.resolve_relations()
+
+    assert cluster.data.get("scope_id") is site, "scope was left as a plain id"
+
+
+def test_a_site_object_survives_resolving(inventory):
+    site = inventory.add_object(NBSite, data={"name": "site1"}, read_from_netbox=True)
+    ctype = inventory.add_object(NBClusterType, data={"name": "vmware"}, read_from_netbox=True)
+
+    cluster = inventory.add_object(NBCluster, data={
+        "name": "c1", "type": ctype, "scope_type": "dcim.site", "scope_id": site,
+    }, read_from_netbox=True)
+    cluster.resolve_relations()
+
+    assert cluster.data.get("scope_id") is site
+    assert cluster.data.get("scope_type") == "dcim.site", "scope type was dropped"
+
+
+def test_source_scopes_a_cluster_with_the_site_object(vcsim, inventory, load_config, vmware_settings):
+    """A dict here is sent to NetBox as is and rejected with 'scope_id: A valid integer is required.'"""
+    from module.sources import instantiate_sources
+
+    load_config(vmware_settings + "cluster_site_relation = .* = site1\n")
+    source = instantiate_sources()[0]
+    assert source.init_successful
+    inventory.resolve_relations()
+    source.apply()
+
+    clusters = list(inventory.get_all_items(NBCluster))
+    assert clusters, "no cluster was synced"
+    for cluster in clusters:
+        scope = cluster.data.get("scope_id")
+        assert isinstance(scope, NBSite), f"scope_id is {type(scope).__name__}, NetBox needs an object it can turn into an id"
+        assert scope.get_display_name() == "site1"


### PR DESCRIPTION
Found this by running development against a real NetBox 4.4.5 rather than the test inventory, and it is bad: with `cluster_site_relation` set, no cluster can be created at all on NetBox 4.2 or newer.

`add_cluster()` puts `{"name": <site>}` into `scope_id`. Everything else in the payload gets turned into an id by `get_nb_reference()`, but a plain dict is passed through, so NetBox answers:

    POST /api/virtualization/clusters/ 400
    {'scope_id': ['A valid integer is required.']}
    data: {..., 'scope_type': 'dcim.site', 'scope_id': {'name': 'e2e-site'}}

The cluster is never created, and every host and VM that referenced it then fails with "updated item cluster ... could not be fully resolved". On the vc001 capture that was 43 errors and 0 clusters, while 34 VMs and 3 hosts were still written, pointing at nothing.

Two changes. `add_cluster()` now puts the site object itself into `scope_id`. And `NBCluster` gets the `scope_id`/`scope_type` handling `NBVLANGroup` already has: the data model lists the allowed scope classes, and `resolve_relations()` calls `resolve_scoped_relations()`. Without that second part NetBox hands the scope back as an id, the id never matches the object, and every run logs `scope_id changed from '2' to 'e2e-site'` and patches the cluster again.

Measured on NetBox 4.4.5 with the vc001 capture: before, 0 clusters and 43 errors; after, the cluster exists scoped to the site, hosts and VMs attach to it, 0 errors, and two further runs change nothing. `cluster_site_relation = .* = <NONE>` is also clean, cluster unscoped, idempotent.

`tests/test_cluster_scope.py` covers both halves and both fail on development: `scope_id` ends up a dict after a sync, and a scope read back as an id is not resolved. Suite 141.

If it is useful I can turn the throwaway stand I used for this - NetBox in docker plus vcsim, wired to `netbox-sync.py` - into something reusable. There is no end-to-end coverage against a real NetBox today and this is the kind of thing it catches.
