### PR TITLE
vmware: keep IPs when guest tools report no interface at all

### DIFF
--- a/module/sources/common/source_base.py
+++ b/module/sources/common/source_base.py
@@ -429,6 +429,15 @@ class SourceBase:
         if type(device_object) == NBVM and grab(vmware_object,'guest.toolsRunningStatus') != "guestToolsRunning":
             log.debug(f"VM '{device_object.name}' guest tool status is 'NotRunning', skipping IP handling")
             skip_ip_handling = True
+        elif type(device_object) == NBVM and len(grab(vmware_object, "guest.net", fallback=list())) == 0:
+            # guest tools report "running" but returned zero NICs for the whole VM -- this is a stale/
+            # incompatible guest tools install (seen on old TMOS releases), not a real "all interfaces lost
+            # their IP" event. Trusting it would tear down otherwise-valid NetBox IP-to-interface assignments
+            # every sync cycle. A real per-NIC IP removal still reports the NIC (with no IP), so that case is
+            # unaffected by this guard.
+            log.debug(f"VM '{device_object.name}' guest tools running but reported zero network interfaces; "
+                      f"skipping IP handling (stale/incompatible VMware Tools?)")
+            skip_ip_handling = True
 
         ip_address_objects = list()
         matching_ip_prefixes = list()

--- a/module/sources/common/source_base.py
+++ b/module/sources/common/source_base.py
@@ -429,15 +429,6 @@ class SourceBase:
         if type(device_object) == NBVM and grab(vmware_object,'guest.toolsRunningStatus') != "guestToolsRunning":
             log.debug(f"VM '{device_object.name}' guest tool status is 'NotRunning', skipping IP handling")
             skip_ip_handling = True
-        elif type(device_object) == NBVM and len(grab(vmware_object, "guest.net", fallback=list())) == 0:
-            # guest tools report "running" but returned zero NICs for the whole VM -- this is a stale/
-            # incompatible guest tools install (seen on old TMOS releases), not a real "all interfaces lost
-            # their IP" event. Trusting it would tear down otherwise-valid NetBox IP-to-interface assignments
-            # every sync cycle. A real per-NIC IP removal still reports the NIC (with no IP), so that case is
-            # unaffected by this guard.
-            log.debug(f"VM '{device_object.name}' guest tools running but reported zero network interfaces; "
-                      f"skipping IP handling (stale/incompatible VMware Tools?)")
-            skip_ip_handling = True
 
         ip_address_objects = list()
         matching_ip_prefixes = list()
@@ -689,6 +680,17 @@ class SourceBase:
         # keyed on what the source reported, not on what survived parsing: an unusable address
         # is still a statement that the interface was seen
         skip_ip_removal = keep_undiscovered_ips is True and len(interface_ips or list()) == 0
+
+        # guest tools which report as running but hand back no interface at all are broken
+        # (seen on old TMOS releases), not a statement that every address is gone. Keep what is
+        # in NetBox instead of tearing it off on every run. A real removal still reports the
+        # interface, just without an address, so that case is unaffected
+        reported_interfaces = grab(vmware_object, "guest.net")
+        if type(device_object) == NBVM and isinstance(reported_interfaces, list) and \
+                len(reported_interfaces) == 0:
+            log.debug(f"VM '{device_object.name}' guest tools report no network interface at all, "
+                      f"keeping the addresses currently assigned in NetBox")
+            skip_ip_removal = True
 
         for current_ip in interface_object.get_ip_addresses():
 

--- a/tests/test_vmware_empty_guest_net.py
+++ b/tests/test_vmware_empty_guest_net.py
@@ -1,0 +1,89 @@
+"""
+VMware Tools that report as running but hand back no interfaces at all are broken,
+not a statement that every IP is gone. Trusting them tears the IP assignments off a
+VM on every run (from #509 by @dirtycache).
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from module.netbox.inventory import NetBoxInventory
+from module.netbox.object_classes import (
+    NBCluster, NBClusterType, NBIPAddress, NBSite, NBVM, NBVMInterface,
+)
+from module.sources.common.source_base import SourceBase
+
+TOOLS_RUNNING_NO_NICS = SimpleNamespace(
+    guest=SimpleNamespace(toolsRunningStatus="guestToolsRunning", net=[]))
+TOOLS_RUNNING_WITH_NIC = SimpleNamespace(
+    guest=SimpleNamespace(toolsRunningStatus="guestToolsRunning",
+                          net=[SimpleNamespace(ipAddress=[])]))
+
+
+@pytest.fixture
+def inventory():
+    def _reset():
+        inv = NetBoxInventory()
+        inv.base_structure = {}
+        inv.source_list = []
+        inv.init()
+        inv.netbox_api_version = "4.0.0"
+        return inv
+    inv = _reset()
+    yield inv
+    _reset()
+
+
+def _source(inventory):
+    src = SourceBase()
+    src.inventory = inventory
+    src.name = "test"
+    src.source_tag = "Source: test"
+    src.settings = SimpleNamespace(
+        skip_fhrp_group_ips=False, preserve_primary_ips=False,
+        ip_tenant_inheritance_order=["disabled"], disable_vlan_sync=True,
+        vlan_group_relation_by_id=None, vlan_group_relation_by_name=None,
+        vlan_sync_exclude_by_id=None, vlan_sync_exclude_by_name=None,
+    )
+    src.return_longest_matching_prefix_for_ip = lambda *a, **k: None
+    return src
+
+
+def _vm_with_ip(inv):
+    site = inv.add_object(NBSite, data={"name": "site1"}, read_from_netbox=True)
+    ctype = inv.add_object(NBClusterType, data={"name": "vmware"}, read_from_netbox=True)
+    cluster = inv.add_object(NBCluster, data={"name": "c1", "type": ctype, "scope": site},
+                             read_from_netbox=True)
+    vm = inv.add_object(NBVM, data={"name": "vm1", "cluster": cluster, "status": "active"},
+                        read_from_netbox=True)
+    nic = inv.add_object(NBVMInterface, data={"name": "eth0", "virtual_machine": vm, "enabled": True},
+                         read_from_netbox=True)
+    ip = inv.add_object(NBIPAddress, data={
+        "address": "10.0.0.5/24",
+        "assigned_object_type": "virtualization.vminterface",
+        "assigned_object_id": nic,
+    }, read_from_netbox=True)
+    return vm, nic, ip
+
+
+def test_broken_tools_reporting_no_interfaces_keep_the_ips(inventory):
+    vm, nic, ip = _vm_with_ip(inventory)
+
+    _source(inventory).add_update_interface(
+        interface_object=nic, device_object=vm, interface_data={"name": "eth0"},
+        interface_ips=[], vmware_object=TOOLS_RUNNING_NO_NICS)
+
+    assert "assigned_object_id" not in ip.unset_items, \
+        "the VM lost its IP because the guest tools returned nothing"
+
+
+def test_a_reported_interface_without_ips_still_removes_them(inventory):
+    # control: the guard must not stop a real removal, where the NIC is reported but has no IP
+    vm, nic, ip = _vm_with_ip(inventory)
+
+    _source(inventory).add_update_interface(
+        interface_object=nic, device_object=vm, interface_data={"name": "eth0"},
+        interface_ips=[], vmware_object=TOOLS_RUNNING_WITH_NIC)
+
+    assert "assigned_object_id" in ip.unset_items, \
+        "a genuinely empty interface must still drop its IP"


### PR DESCRIPTION
Taken from #509 by @dirtycache, his commit is the first one here.

The bug is real and generic: when VMware Tools answer "running" but hand back an empty `guest.net`, the sync reads that as "this VM has no addresses any more" and strips every IP-to-interface assignment it has in NetBox, every run. He saw it on old TMOS releases.

I moved the guard, though. As written it set `skip_ip_handling`, which also stops addresses being *assigned*, and it treated a missing `guest.net` the same as an empty one - that broke four existing tests, where the caller passes the addresses in explicitly and the fake VM object has no `guest.net` at all. It now only suppresses the removal, and only when `guest.net` is actually present and actually empty. A genuine removal still reports the interface without an address, so that path is untouched.

`tests/test_vmware_empty_guest_net.py` has both sides: broken tools keep the address, an interface that really is empty still drops it. The first fails without the guard. Suite 143, and a sync against a real NetBox 4.7 is unchanged, 0 errors and a second run with 0 changes.

The rest of #509 is a different matter - it has grown to 28 commits with vendor-specific handling for ACOS, TMOS and Alteon, plus DNS-based primary IP selection and VCSA metadata. I'll comment there separately.