### PR TITLE
check_redfish: stop syncing the live fan reading

### DIFF
--- a/module/sources/check_redfish/import_inventory.py
+++ b/module/sources/check_redfish/import_inventory.py
@@ -446,23 +446,16 @@ class CheckRedfish(SourceBase):
             health_status = get_string_or_none(grab(fan, "health_status"))
             physical_context = get_string_or_none(grab(fan, "physical_context"))
             fan_id = get_string_or_none(grab(fan, "id"))
-            reading = get_string_or_none(grab(fan, "reading"))
-            reading_unit = get_string_or_none(grab(fan, "reading_unit"))
-
             description = list()
-            speed = None
             if physical_context is not None:
                 description.append(f"Context: {physical_context}")
 
-            if reading is not None and reading_unit is not None:
-                reading_unit = "%" if reading_unit.lower() == "percent" else reading_unit
-                speed = f"{reading}{reading_unit}"
-
+            # a fan's reading is a live measurement, not something the inventory describes.
+            # Writing it would update this object in NetBox on every single run
             items.append({
                 "description": description,
                 "full_name": f"{fan_name} (ID: {fan_id})",
-                "health": health_status,
-                "speed": speed
+                "health": health_status
             })
 
         self.update_all_items(items, "Fan")

--- a/tests/test_check_redfish_fan_speed.py
+++ b/tests/test_check_redfish_fan_speed.py
@@ -1,0 +1,40 @@
+"""
+A fan's reading is a live measurement. Syncing it means NetBox records a change on
+every run, for every fan of every server (reported by @marcinpsk on #473).
+"""
+from module.sources.check_redfish.import_inventory import CheckRedfish
+
+
+def _fan(reading):
+    return {"inventory": {"fan": [{
+        "id": "Fan.Embedded.1", "name": "Fan1A", "health_status": "OK",
+        "physical_context": "SystemBoard", "reading": reading, "reading_unit": "RPM",
+    }]}}
+
+
+def _collect(inventory, reading):
+    source = object.__new__(CheckRedfish)
+    source.inventory = inventory
+    source.name = "redfish"
+    source.source_tag = "Source: redfish"
+    source.inventory_file_content = _fan(reading)
+    collected = []
+    source.update_all_items = lambda items, inventory_type: collected.extend(items)
+    source.update_fan()
+    return collected
+
+
+def test_a_spinning_fan_produces_the_same_item(inventory):
+    slow = _collect(inventory, 7015)
+    fast = _collect(inventory, 9120)
+
+    assert slow == fast, "the fan item changes with its rpm, so NetBox is written on every run"
+
+
+def test_the_fan_is_still_described(inventory):
+    # control: dropping the reading must not empty the item
+    item = _collect(inventory, 8280)[0]
+
+    assert item["full_name"] == "Fan1A (ID: Fan.Embedded.1)"
+    assert item["health"] == "OK"
+    assert "Context: SystemBoard" in item["description"]


### PR DESCRIPTION
@marcinpsk raised this on #473: fan speed is a live measurement, so it churns.

Confirmed against a real NetBox 4.7. Bump the reading in the inventory file between two runs and the fan is written again - once per fan, per server, per run, forever, and every one of those lands in the NetBox changelog. It happens on both paths, the inventory item and the module, because both take `speed` from the same item data.

The other components that fill `speed` are describing the part rather than measuring it - DIMM clock, drive rpm rating, NIC link speed - so they stay. Only the fan reading is dropped; the fan is still synced with its name, health and physical context.

One thing I did not touch: a CPU's `current_speed` could drift the same way on hardware that reports the live clock instead of the rated one. I have no data on that, and nobody has reported it, so I left it alone rather than guess.

`tests/test_check_redfish_fan_speed.py` collects the same fan at two different rpm and expects one identical item; it fails on development. Suite 145, and the e2e run after an rpm jump now reports no change at all.